### PR TITLE
LearningRecord と Profile モデルの supabaseUserId を使用するための変更

### DIFF
--- a/prisma/migrations/20250328101519_y/migration.sql
+++ b/prisma/migrations/20250328101519_y/migration.sql
@@ -1,0 +1,39 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `userId` on the `LearningRecord` table. All the data in the column will be lost.
+  - You are about to drop the column `userId` on the `Profile` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[supabaseUserId]` on the table `Profile` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[supabaseUserId]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `supabaseUserId` to the `LearningRecord` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `supabaseUserId` to the `Profile` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "LearningRecord" DROP CONSTRAINT "LearningRecord_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Profile" DROP CONSTRAINT "Profile_userId_fkey";
+
+-- DropIndex
+DROP INDEX "Profile_userId_key";
+
+-- AlterTable
+ALTER TABLE "LearningRecord" DROP COLUMN "userId",
+ADD COLUMN     "supabaseUserId" VARCHAR(255) NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Profile" DROP COLUMN "userId",
+ADD COLUMN     "supabaseUserId" VARCHAR(255) NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Profile_supabaseUserId_key" ON "Profile"("supabaseUserId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_supabaseUserId_key" ON "User"("supabaseUserId");
+
+-- AddForeignKey
+ALTER TABLE "Profile" ADD CONSTRAINT "Profile_supabaseUserId_fkey" FOREIGN KEY ("supabaseUserId") REFERENCES "User"("supabaseUserId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LearningRecord" ADD CONSTRAINT "LearningRecord_supabaseUserId_fkey" FOREIGN KEY ("supabaseUserId") REFERENCES "User"("supabaseUserId") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,7 +22,7 @@ model Role {
 
 model User {
   id            Int      @id @default(autoincrement())
-  supabaseUserId String   @db.VarChar(255)
+  supabaseUserId String   @db.VarChar(255) @unique  // supabaseUserId に @unique 属性を追加
   roleId        Int
   nickname      String
   role          Role     @relation(fields: [roleId], references: [id])
@@ -34,7 +34,7 @@ model User {
 
 model Profile {
   id             Int      @id @default(autoincrement())
-  userId         Int     @unique
+  supabaseUserId String   @db.VarChar(255) @unique  // supabaseUserId に @unique 属性を追加
   first_name     String
   last_name      String
   date_of_birth  DateTime
@@ -43,21 +43,21 @@ model Profile {
   bio            String
   phoneNumber    String
   socialLinks    String
-  user           User     @relation(fields: [userId], references: [id])
+  user           User     @relation(fields: [supabaseUserId], references: [supabaseUserId])
 }
 
-model LearningRecord {
-  id          Int       @id @default(autoincrement())
-  userId      Int
-  categoryId  Int
-  title       String
-  content     String
-  start_time  DateTime
-  end_time    DateTime
-  duration    Float
-  learning_date DateTime
-  user        User      @relation(fields: [userId], references: [id])
-  category    Category  @relation(fields: [categoryId], references: [id])
+model Follower {
+  id             Int       @id @default(autoincrement())
+  followerId     Int
+  followedId     Int
+  follower       User      @relation("follower", fields: [followerId], references: [id])
+  followed       User      @relation("followed", fields: [followedId], references: [id])
+}
+
+model Category {
+  id               Int        @id @default(autoincrement())
+  category_name    String
+  learningRecords  LearningRecord[]
   learningRecordCategories LearningRecordCategory[]
 }
 
@@ -69,17 +69,17 @@ model LearningRecordCategory {
   category       Category   @relation(fields: [categoryId], references: [id])
 }
 
-model Category {
-  id               Int        @id @default(autoincrement())
-  category_name    String
-  learningRecords  LearningRecord[]
+model LearningRecord {
+  id            Int       @id @default(autoincrement())
+  supabaseUserId String  @db.VarChar(255)
+  categoryId    Int
+  title         String
+  content       String
+  start_time    DateTime
+  end_time      DateTime
+  duration      Float
+  learning_date DateTime
+  user          User      @relation(fields: [supabaseUserId], references: [supabaseUserId])
+  category      Category @relation(fields: [categoryId], references: [id])
   learningRecordCategories LearningRecordCategory[]
-}
-
-model Follower {
-  id             Int       @id @default(autoincrement())
-  followerId     Int
-  followedId     Int
-  follower       User      @relation("follower", fields: [followerId], references: [id])
-  followed       User      @relation("followed", fields: [followedId], references: [id])
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -41,7 +41,7 @@ async function main() {
   // 学習記録の作成
   await prisma.learningRecord.create({
     data: {
-      userId: user.id,
+      supabaseUserId: user.supabaseUserId, // supabaseUserId を使用
       categoryId: category.id,
       title: "Prisma Basics",
       content: "Learning how to use Prisma ORM",


### PR DESCRIPTION
# プルリクエスト: LearningRecord と Profile モデルの supabaseUserId を使用するための変更

## 概要
このプルリクエストは、`LearningRecord` と `Profile` モデルを、ユーザー認証に使用する Supabase の `supabaseUserId` に基づいて関連付ける変更を含んでいます。これにより、`userId` を使用していた部分を `supabaseUserId` に変更し、正しくデータベースを操作できるようにします。

## 変更点

### 1. **User モデル**
- `supabaseUserId` フィールドに `@unique` 属性を追加。
- `supabaseUserId` を参照するリレーションの変更を反映。
  
```prisma
model User {
  id            Int      @id @default(autoincrement())
  supabaseUserId String   @db.VarChar(255) @unique
  roleId        Int
  nickname      String
  role          Role     @relation(fields: [roleId], references: [id])
  profile       Profile?
  learningRecords LearningRecord[]
  followers      Follower[] @relation("follower")
  followedBy     Follower[] @relation("followed")
}
```

### 2. **LearningRecord モデル**
- `userId` を `supabaseUserId` に変更。
- `user` リレーションを `supabaseUserId` を基に修正。

```prisma
model LearningRecord {
  id            Int       @id @default(autoincrement())
  supabaseUserId String  @db.VarChar(255) // userId を supabaseUserId に変更
  categoryId    Int
  title         String
  content       String
  start_time    DateTime
  end_time      DateTime
  duration      Float
  learning_date DateTime
  user          User     @relation(fields: [supabaseUserId], references: [supabaseUserId]) // supabaseUserId で参照
  category      Category @relation(fields: [categoryId], references: [id])
  learningRecordCategories LearningRecordCategory[]
}
```

supabaseUserId を基に user リレーションが修正され、userId ではなく supabaseUserId を使用して関連付けを行うようになります。

supabaseUserId の型は @db.VarChar(255) とし、supabaseUserId フィールドにはユニーク制約を適用します。

この変更により、LearningRecord モデルは User モデルの supabaseUserId を基に関連付けられます。