### PR TITLE
メール確認・再送信機能の改善、ユーザー情報の修正

### DIFF
--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -3,11 +3,11 @@ import { prisma } from "@/app/_utils/prisma";
 
 export async function POST(request: Request) {
   try {
-    const { nickname, user_id } = await request.json();
+    const { nickname, supabaseUserId } = await request.json();
 
     const newUser = await prisma.user.create({
       data: {
-        supabaseUserId: user_id, // SupabaseのユーザーID
+        supabaseUserId, // SupabaseのユーザーID
         nickname: nickname, // フォームからのニックネーム
         roleId: 1, // デフォルトでroleId 1
       },

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,25 +1,39 @@
-import { NextResponse } from "next/server";
 import { prisma } from "@/app/_utils/prisma";
 
 export async function POST(request: Request) {
   try {
+    // リクエストボディからnicknameとsupabaseUserIdを抽出
     const { nickname, supabaseUserId } = await request.json();
 
+    // ユーザーがすでに存在するかチェック
+    const existingUser = await prisma.user.findUnique({
+      where: {
+        supabaseUserId: supabaseUserId, // supabaseUserId で検索
+      },
+    });
+
+    // すでにユーザーが存在する場合はエラーメッセージを返す
+    if (existingUser) {
+      return new Response(
+        JSON.stringify({ message: "ユーザーはすでに存在します。" }),
+        { status: 400 }
+      );
+    }
+
+    // 新しいユーザーを作成（デフォルトのroleIdは1）
     const newUser = await prisma.user.create({
       data: {
-        supabaseUserId, // SupabaseのユーザーID
-        nickname: nickname, // フォームからのニックネーム
+        supabaseUserId,
+        nickname,
         roleId: 1, // デフォルトでroleId 1
       },
     });
-    console.log("User saved to Prisma:", newUser); // ユーザーが保存されたか確認
 
-    return NextResponse.json({ newUser });
+    // 作成したユーザー情報を返す
+    return new Response(JSON.stringify(newUser), { status: 200 });
   } catch (error) {
-    console.error("ユーザー情報の保存に失敗しました:", error);
-    return NextResponse.json(
-      { error: "ユーザー情報の保存に失敗しました" },
-      { status: 500 }
-    );
+    // エラーログを出力し、エラーレスポンスを返す
+    console.error("ユーザー情報の保存に失敗しました", error);
+    return new Response("ユーザー情報の保存に失敗しました", { status: 500 });
   }
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -39,11 +39,9 @@ export default function LoginPage() {
       console.log("認証エラー:", authError.message); // エラー時にエラーメッセージをログに出力
       setError(authError.message); // エラーメッセージを設定
 
-      // Email not confirmedエラーの場合にアラート表示
+      // Email not confirmedエラーの場合に再送信ボタン表示
       if (authError.message === "Email not confirmed") {
-        alert(
-          "認証エラー: メールアドレスが未確認です。確認メールを開封してください。"
-        );
+        setError("メールアドレスが未確認です。確認メールを開封してください。");
       }
 
       return null;
@@ -63,12 +61,12 @@ export default function LoginPage() {
 
   // 確認メールを再送信する関数
   const resendVerificationEmail = async () => {
-    const email = getValues("email"); // getValues でフォームのメールアドレスを取得
+    const email = getValues("email"); // フォームからメールアドレスを取得
 
-    // 確認メールを再送信する
+    // 確認メールを再送信するために、仮のパスワードを使ってsignUpを呼び出す
     const { error } = await supabase.auth.signUp({
       email,
-      password: "", // パスワードは空でOK
+      password: "temporarypassword", // 仮のパスワードを設定（実際には変更されません）
     });
 
     if (error) {

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -8,21 +8,25 @@ import { Label } from "@ui/label"; // ラベルコンポーネントのインポ
 import { Button } from "@ui/button"; // ボタンコンポーネントのインポート
 import { Input } from "@ui/input"; // 入力フォームコンポーネントのインポート
 import Link from "next/link"; // リンクコンポーネントのインポート
-import { LoginFormData } from "@/app/_types/formTypes"; // フォームデータの型定義}
-import AppLogoLink from "../_components/AppLogoLink";
+import { LoginFormData } from "@/app/_types/formTypes"; // フォームデータの型定義
+import AppLogoLink from "../_components/AppLogoLink"; // アプリロゴリンクのコンポーネント
 
 export default function LoginPage() {
   const [error, setError] = useState<string | null>(null); // エラーメッセージの状態管理
+  const [emailSent, setEmailSent] = useState<boolean>(false); // 確認メール送信状態
   const router = useRouter(); // useRouterフックを使用してページ遷移
 
   const {
     register,
     handleSubmit,
-    formState: { errors }, // フォームエラーの状態を管理
+    formState: { errors },
+    getValues, // getValues をインポートしてフォームの値を取得
   } = useForm<LoginFormData>(); // react-hook-formのuseFormフック
 
   // ログイン処理
   const handleLogin = async (email: string, password: string) => {
+    console.log("ログイン処理開始", { email }); // ログイン開始時にemailをログに出力
+
     // supabaseのサインイン処理
     const { data: userData, error: authError } =
       await supabase.auth.signInWithPassword({
@@ -32,16 +36,46 @@ export default function LoginPage() {
 
     // 認証エラーがある場合
     if (authError) {
+      console.log("認証エラー:", authError.message); // エラー時にエラーメッセージをログに出力
       setError(authError.message); // エラーメッセージを設定
+
+      // Email not confirmedエラーの場合にアラート表示
+      if (authError.message === "Email not confirmed") {
+        alert(
+          "認証エラー: メールアドレスが未確認です。確認メールを開封してください。"
+        );
+      }
+
       return null;
     }
 
     // ユーザーが確認されている場合、ユーザー情報を返す
     if (userData?.user?.confirmed_at) {
+      console.log("ログイン成功:", userData.user); // ユーザー情報をログに出力
+      setError(null); // ログイン成功時にエラーメッセージをクリア
       return userData.user;
     } else {
+      console.log("未確認のメールアドレス"); // メール未確認時にログに出力
       setError("メールアドレスが未確認です。確認メールを開封してください。"); // メール確認を促すエラー
       return null;
+    }
+  };
+
+  // 確認メールを再送信する関数
+  const resendVerificationEmail = async () => {
+    const email = getValues("email"); // getValues でフォームのメールアドレスを取得
+
+    // 確認メールを再送信する
+    const { error } = await supabase.auth.signUp({
+      email,
+      password: "", // パスワードは空でOK
+    });
+
+    if (error) {
+      alert("確認メールの再送信に失敗しました: " + error.message);
+    } else {
+      setEmailSent(true); // 再送信後に状態を更新
+      alert("確認メールを再送信しました。");
     }
   };
 
@@ -52,7 +86,7 @@ export default function LoginPage() {
 
     // ログイン成功時、ホームページにリダイレクト
     if (user) {
-      router.push("/");
+      router.push("/"); // ログイン成功後、ホームページにリダイレクト
     }
   };
 
@@ -102,7 +136,6 @@ export default function LoginPage() {
               <p className="text-sm text-red-500">{errors.email.message}</p> // エラーメッセージ表示
             )}
           </div>
-
           {/* パスワード入力フォーム */}
           <div className="space-y-1">
             <Label htmlFor="password">パスワード</Label>
@@ -123,9 +156,28 @@ export default function LoginPage() {
               <p className="text-sm text-red-500">{errors.password.message}</p> // エラーメッセージ表示
             )}
           </div>
-
           {/* エラーメッセージ */}
-          {error && <p className="text-red-500 text-sm">{error}</p>}
+          {error && <p className="text-red-500 text-sm">{error}</p>}{" "}
+          {/* 認証エラーを表示 */}
+          {/* メール確認再送信ボタン */}
+          {error &&
+            error ===
+              "メールアドレスが未確認です。確認メールを開封してください。" && (
+              <div className="mt-4">
+                <Button
+                  type="button"
+                  onClick={resendVerificationEmail} // 再メール送信
+                  className="w-full bg-pink-500 text-white hover:bg-pink-600"
+                >
+                  確認メールを再送信
+                </Button>
+                {emailSent && (
+                  <p className="text-green-500 text-sm mt-2">
+                    確認メールを再送信しました。
+                  </p>
+                )}
+              </div>
+            )}
         </div>
 
         <Button

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -18,8 +18,6 @@ export default function SignUpPage() {
   } = useForm<SignUpFormData>();
 
   const onSubmit = async (data: SignUpFormData) => {
-    console.log("SignUp Data: ", data); // フォーム送信時にデータを表示
-
     const { email, password, nickname } = data;
 
     // Supabase 認証のサインアップ
@@ -28,7 +26,7 @@ export default function SignUpPage() {
         email,
         password,
         options: {
-          emailRedirectTo: `http://localhost:3000/login`,
+          emailRedirectTo: `http://localhost:3000/login`, // メール確認後のリダイレクトURL
         },
       }
     );
@@ -43,6 +41,7 @@ export default function SignUpPage() {
       const user = signUpData?.user; // auth.users からユーザーを取得
       console.log("User created: ", user); // ユーザー情報の確認用ログ
 
+      // サインアップが成功した場合、Userテーブルにニックネームを保存
       if (user) {
         // ユーザー情報をサーバーサイドで保存するAPIを呼び出す
         const response = await fetch("/api/users", {
@@ -53,12 +52,14 @@ export default function SignUpPage() {
           body: JSON.stringify({
             email,
             nickname,
-            user_id: user.id, // SupabaseのユーザーID
+            supabaseUserId: user.id, // supabaseUserIdを追加
           }),
         });
 
         if (response.ok) {
-          alert("確認メールを送信しました。");
+          alert(
+            "確認メールを送信しました。メールを確認して、リンクをクリックしてください。"
+          );
         } else {
           console.error("ユーザー情報の保存に失敗しました");
         }

--- a/src/app/user/profile/register/page.tsx
+++ b/src/app/user/profile/register/page.tsx
@@ -39,6 +39,8 @@ export default function ProfileRegistrationPage() {
   const { session, token, isLoading } = useSession(); // sessionとtokenを取得
   const router = useRouter(); // useRouterを直接使用
 
+  console.log("セッション:", session); // セッション情報をログに出力
+
   // ページロード時にトークンを確認
   useEffect(() => {
     if (isLoading) return; // ローディング中は何もしない


### PR DESCRIPTION
## プルリクエスト内容: メール確認・再送信機能の改善、ユーザー情報の修正

### 概要
このプルリクエストでは、以下の変更を行いました：
1. **ログイン処理の改善**: 認証エラー（未確認のメールアドレス）に対して再確認メールを送信する機能を追加しました。
2. **サインアップ処理の修正**: `supabaseUserId` を使用してユーザー情報を保存するAPIの呼び出しを修正しました。
3. **ユーザー情報取得の修正**: ユーザー情報を取得する際のエラーハンドリングを強化しました。

### 変更点

1. **`src/app/login/page.tsx`**
   - 認証エラーが発生した場合に、メールが未確認であれば再送信のためのボタンを表示。
   - ユーザーが未確認の場合に、再確認メールを再送信できるように `supabase.auth.signUp` を使用して再送信機能を追加。
   - フォーム送信後、ログイン処理が成功した場合にホームページにリダイレクト。

2. **`src/app/api/users/route.ts`**
   - ユーザー情報をサーバーサイドで保存する際、`user_id` を `supabaseUserId` に修正。
   - ユーザー情報保存時にエラー処理を改善。

3. **`src/app/signup/page.tsx`**
   - サインアップ処理でユーザー情報を `supabaseUserId` で保存するAPIを呼び出し、確認メールの送信後のメッセージを修正。
   - ユーザーIDを `user_id` から `supabaseUserId` に変更。

4. **`src/app/_utils/session.ts`**
   - ユーザー情報を取得する際、`supabaseUserId` を使って正しく検索できるように修正。
   - 取得したデータが存在する場合にログに出力するように修正。

### 詳細な変更内容

#### `src/app/login/page.tsx`
- `handleLogin` メソッドにおいて、認証エラーが「メール未確認」の場合に確認メール再送信ボタンを表示。
- `resendVerificationEmail` メソッドを追加し、再確認メールを `supabase.auth.signUp` で再送信。
- ログイン成功時、ホームページへのリダイレクトを実施。

#### `src/app/api/users/route.ts`
- ユーザー情報の保存時に、`user_id` を `supabaseUserId` に修正し、エラー処理を追加。

#### `src/app/signup/page.tsx`
- サインアップ時、ユーザー情報を `supabaseUserId` で保存。
- メール確認後のメッセージを「確認メールを送信しました。メールを確認して、リンクをクリックしてください。」に修正。

#### `src/app/_utils/session.ts`
- ユーザー情報の取得処理で `supabaseUserId` を使ってユーザー情報を検索するように修正。

---

### 動作確認
- ログインページで認証エラー時に再確認メール送信ボタンが表示され、再送信が行えることを確認。
- サインアップ後、メール確認が未完了の場合に確認メールを再送信できることを確認。

