### PR TITLE
Feature/issue16 add learning record dialog supabase user

### DIFF
--- a/src/app/_types/formTypes.ts
+++ b/src/app/_types/formTypes.ts
@@ -17,13 +17,13 @@ export type SignUpFormData = {
 // 学習記録に関連する型
 export type LearningRecord = {
   supabaseUserId: string;
-  categoryId: string;
+  categoryId: number;
   id: string;
   title: string;
   date: Date;
   startTime: string;
   endTime: string;
-  duration: string;
+  duration: number;
   content: string;
 };
 
@@ -39,3 +39,8 @@ export type UserProfile = {
   date_of_birth?: string;
   profile_picture?: string;
 };
+
+export interface Category {
+  id: number;
+  category_name: string;
+}

--- a/src/app/api/category/route.ts
+++ b/src/app/api/category/route.ts
@@ -12,8 +12,6 @@ export async function GET() {
         category_name: true, // カテゴリーの名前を取得
       },
     });
-    console.log("取得したカテゴリー:", categories);
-    // カテゴリーが取得できた場合、レスポンスとして返す
     return NextResponse.json(categories, { status: 200 });
   } catch (error) {
     console.error("カテゴリー取得エラー:", error);

--- a/src/app/api/category/route.ts
+++ b/src/app/api/category/route.ts
@@ -1,0 +1,25 @@
+// src/app/api/category/route.ts
+import { NextResponse } from "next/server";
+import { prisma } from "@/app/_utils/prisma"; // Prisma Clientをインポート
+
+// GETリクエストで全てのカテゴリーを取得
+export async function GET() {
+  try {
+    // Prismaを使ってSupabaseから全てのカテゴリーを取得
+    const categories = await prisma.category.findMany({
+      select: {
+        id: true, // カテゴリーのIDを取得
+        category_name: true, // カテゴリーの名前を取得
+      },
+    });
+    console.log("取得したカテゴリー:", categories);
+    // カテゴリーが取得できた場合、レスポンスとして返す
+    return NextResponse.json(categories, { status: 200 });
+  } catch (error) {
+    console.error("カテゴリー取得エラー:", error);
+    return NextResponse.json(
+      { message: "カテゴリーの取得に失敗しました" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/user/learning-history/_components/AddRecordDialog.tsx
+++ b/src/app/user/learning-history/_components/AddRecordDialog.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState, useEffect } from "react";
 import { Button } from "@ui/button";
 import {
@@ -7,10 +9,10 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
-} from "@ui/dialog";
+} from "@ui/dialog"; // Dialogに必要なコンポーネントをインポート
 import FormField from "./FormField";
 import { LearningRecord, Category } from "@/app/_types/formTypes";
-import { useSession } from "@utils/session"; // SWRで管理されたセッション情報をインポート
+import { useSession } from "@utils/session"; // セッション情報を取得
 
 interface AddRecordDialogProps {
   onAddRecord: (record: LearningRecord) => void;
@@ -28,7 +30,6 @@ const AddRecordDialog = ({ onAddRecord }: AddRecordDialogProps) => {
 
   const { user } = useSession(); // 現在のユーザーのセッション情報を取得
   const token = user?.token; // セッションからトークンを取得
-  // console.log("AddRecordDialog-Token:", token); // トークンのデバッグ用ログ
 
   // サーバーからカテゴリー情報を取得する関数
   const fetchCategories = async () => {
@@ -76,16 +77,6 @@ const AddRecordDialog = ({ onAddRecord }: AddRecordDialogProps) => {
       content, // 学習内容
     };
 
-    // 送信するリクエストのデータをコンソールに表示
-    console.log("Sending new learning record:", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`, // トークンをヘッダーに追加
-      },
-      body: JSON.stringify(newRecord),
-    });
-
     try {
       // 学習記録をサーバーに送信
       const response = await fetch("/api/user/learning-history", {
@@ -97,19 +88,8 @@ const AddRecordDialog = ({ onAddRecord }: AddRecordDialogProps) => {
         body: JSON.stringify(newRecord),
       });
 
-      // 応答が正常でない場合、エラーをスロー
       if (!response.ok) {
         throw new Error("学習記録の保存に失敗しました");
-      }
-
-      const data = await response.json(); // サーバーからの応答データを取得
-
-      // レスポンスデータをコンソールに表示
-      console.log("Response Data:", data);
-
-      // 学習記録の追加成功
-      if (data) {
-        console.log("Success:", data);
       }
 
       // 新しいレコードを状態に追加
@@ -134,10 +114,17 @@ const AddRecordDialog = ({ onAddRecord }: AddRecordDialogProps) => {
           学習記録を追加
         </Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-[425px]">
+      <DialogContent
+        className="sm:max-w-[425px]"
+        aria-describedby="dialog-description" // ダイアログの説明を設定
+      >
         <DialogHeader>
           <DialogTitle>学習記録を追加</DialogTitle>
         </DialogHeader>
+        {/* ダイアログの説明を追加 */}
+        <div id="dialog-description" className="text-sm text-gray-500">
+          ここでは、学習記録を入力し、保存することができます。
+        </div>
         <div className="grid gap-4 py-4">
           {/* カテゴリー選択フォーム */}
           <div className="space-y-1">

--- a/src/app/user/learning-history/_components/AddRecordDialog.tsx
+++ b/src/app/user/learning-history/_components/AddRecordDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Button } from "@ui/button";
 import {
   Dialog,
@@ -9,7 +9,7 @@ import {
   DialogTrigger,
 } from "@ui/dialog";
 import FormField from "./FormField";
-import { LearningRecord } from "@/app/_types/formTypes";
+import { LearningRecord, Category } from "@/app/_types/formTypes";
 import { useSession } from "@utils/session"; // SWRで管理されたセッション情報をインポート
 
 interface AddRecordDialogProps {
@@ -17,44 +17,63 @@ interface AddRecordDialogProps {
 }
 
 const AddRecordDialog = ({ onAddRecord }: AddRecordDialogProps) => {
-  const [title, setTitle] = useState("");
-  const [date, setDate] = useState("");
-  const [startTime, setStartTime] = useState("");
-  const [endTime, setEndTime] = useState("");
-  const [content, setContent] = useState("");
+  const [title, setTitle] = useState(""); // 学習記録のタイトル
+  const [date, setDate] = useState(""); // 学習記録の日付
+  const [startTime, setStartTime] = useState(""); // 学習開始時間
+  const [endTime, setEndTime] = useState(""); // 学習終了時間
+  const [content, setContent] = useState(""); // 学習内容
   const [categoryId, setCategoryId] = useState<string | null>(null); // カテゴリーID
-  const [open, setOpen] = useState(false);
-
-  // カテゴリーのリスト（例）
-  const categories = [
-    { id: "1", name: "プログラミング" },
-    { id: "2", name: "デザイン" },
-    { id: "3", name: "マーケティング" },
-    // ここに他のカテゴリーを追加
-  ];
+  const [open, setOpen] = useState(false); // ダイアログの開閉状態
+  const [categories, setCategories] = useState<Category[]>([]); // カテゴリーリスト
 
   const { user } = useSession(); // 現在のユーザーのセッション情報を取得
-  const token = user?.token; // tokenをセッションから取得
-  console.log("AddRecordDialog-Token:", token); // トークンをコンソールに表示
+  const token = user?.token; // セッションからトークンを取得
+  // console.log("AddRecordDialog-Token:", token); // トークンのデバッグ用ログ
 
+  // サーバーからカテゴリー情報を取得する関数
+  const fetchCategories = async () => {
+    try {
+      const response = await fetch("/api/category"); // GETリクエストでカテゴリー情報を取得
+      if (!response.ok) {
+        throw new Error("カテゴリーの取得に失敗しました");
+      }
+      const data = await response.json();
+      setCategories(data); // 取得したカテゴリーをステートに保存
+    } catch (error) {
+      console.error("カテゴリー取得エラー:", error); // エラーハンドリング
+      alert("カテゴリーの取得に失敗しました");
+    }
+  };
+
+  // コンポーネントがマウントされたときにカテゴリー情報を取得
+  useEffect(() => {
+    fetchCategories(); // fetchCategories関数を実行
+  }, []);
+
+  // フォームが送信されたときに実行される関数
   const handleSubmit = async () => {
+    // 開始時間と終了時間をDateオブジェクトに変換
     const start = new Date(`2000-01-01T${startTime}:00`);
     const end = new Date(`2000-01-01T${endTime}:00`);
+
+    // 時間差を計算して時間と分に分ける
     const diffMs = end.getTime() - start.getTime();
     const hours = Math.floor(diffMs / (1000 * 60 * 60));
     const minutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
-    const duration = `${hours}時間${minutes.toString().padStart(2, "0")}分`;
+
+    // durationをFloat型に変換（時間単位）
+    const duration = hours + minutes / 60;
 
     const newRecord: LearningRecord = {
-      id: Math.random().toString(36).substring(2, 9),
-      supabaseUserId: user?.id ?? "", // ユーザーIDを使用
-      categoryId: categoryId ?? "", // カテゴリーID
+      id: Math.random().toString(36).substring(2, 9), // 新しいIDを生成
+      supabaseUserId: user?.id ?? "", // ユーザーID
+      categoryId: categoryId ? parseInt(categoryId) : 0, // カテゴリーIDを整数に変換
       title,
-      date: new Date(date),
+      date: new Date(date), // 学習日付
       startTime,
       endTime,
-      duration,
-      content,
+      duration, // 学習時間
+      content, // 学習内容
     };
 
     // 送信するリクエストのデータをコンソールに表示
@@ -68,6 +87,7 @@ const AddRecordDialog = ({ onAddRecord }: AddRecordDialogProps) => {
     });
 
     try {
+      // 学習記録をサーバーに送信
       const response = await fetch("/api/user/learning-history", {
         method: "POST",
         headers: {
@@ -77,29 +97,32 @@ const AddRecordDialog = ({ onAddRecord }: AddRecordDialogProps) => {
         body: JSON.stringify(newRecord),
       });
 
+      // 応答が正常でない場合、エラーをスロー
       if (!response.ok) {
         throw new Error("学習記録の保存に失敗しました");
       }
 
-      const data = await response.json();
+      const data = await response.json(); // サーバーからの応答データを取得
 
       // レスポンスデータをコンソールに表示
       console.log("Response Data:", data);
 
+      // 学習記録の追加成功
       if (data) {
-        console.log("Success:", data); // 成功のレスポンスをログに表示
+        console.log("Success:", data);
       }
 
-      onAddRecord(newRecord); // 新しいレコードを追加
+      // 新しいレコードを状態に追加
+      onAddRecord(newRecord); // 親コンポーネントに新しいレコードを追加する関数を呼び出す
       setOpen(false); // ダイアログを閉じる
-      setTitle("");
-      setDate("");
-      setStartTime("");
-      setEndTime("");
-      setContent("");
+      setTitle(""); // タイトルをリセット
+      setDate(""); // 日付をリセット
+      setStartTime(""); // 開始時間をリセット
+      setEndTime(""); // 終了時間をリセット
+      setContent(""); // 内容をリセット
       setCategoryId(null); // カテゴリー選択をリセット
     } catch (error) {
-      console.error(error);
+      console.error(error); // エラーハンドリング
       alert("学習記録の保存に失敗しました");
     }
   };
@@ -124,17 +147,18 @@ const AddRecordDialog = ({ onAddRecord }: AddRecordDialogProps) => {
             <select
               id="categoryId"
               value={categoryId ?? ""}
-              onChange={(e) => setCategoryId(e.target.value)}
+              onChange={(e) => setCategoryId(e.target.value)} // 選択したカテゴリーIDをステートに保存
               className="h-10 w-full border-gray-300 rounded-md p-2"
             >
               <option value="">カテゴリーを選択</option>
               {categories.map((category) => (
                 <option key={category.id} value={category.id}>
-                  {category.name}
+                  {category.category_name} {/* カテゴリー名を表示 */}
                 </option>
               ))}
             </select>
           </div>
+          {/* 学習記録のその他のフィールド */}
           <FormField
             label="タイトル"
             id="title"
@@ -174,7 +198,7 @@ const AddRecordDialog = ({ onAddRecord }: AddRecordDialogProps) => {
         <DialogFooter>
           <Button
             type="button"
-            onClick={handleSubmit}
+            onClick={handleSubmit} // 送信ボタンをクリックした際に学習記録を保存
             className="bg-pink-500 hover:bg-pink-600"
           >
             追加

--- a/src/app/user/learning-history/_components/LearningRecordTable.tsx
+++ b/src/app/user/learning-history/_components/LearningRecordTable.tsx
@@ -13,7 +13,6 @@ import { Edit, Trash } from "lucide-react"; // 編集と削除アイコンのイ
 import { format } from "date-fns"; // 日付のフォーマットを行うためのライブラリ
 import { ja } from "date-fns/locale"; // 日本語ロケールをインポート
 import { LearningRecord } from "@/app/_types/formTypes"; // 学習記録の型をインポート
-import "@components/ActionButton"; // ActionButtonコンポーネントをインポート
 import ActionButton from "@components/ActionButton"; // ActionButtonコンポーネントをインポート
 
 // LearningRecordTableコンポーネントに渡されるpropsの型定義
@@ -29,45 +28,32 @@ const LearningRecordTable: React.FC<LearningRecordTableProps> = ({
   handleDeleteRecord, // 削除用の関数
   handleEditRecord, // 編集用の関数
 }) => {
-  // コンソールに取得したrecordsを表示
-  console.log("取得した学習記録:", records);
-
   return (
     <div className="rounded-md border">
       <Table>
-        {/* テーブルのヘッダー部分 */}
         <TableHeader>
           <TableRow>
-            <TableHead>タイトル</TableHead> {/* タイトル列 */}
-            <TableHead>日付</TableHead> {/* 日付列 */}
-            <TableHead>時間</TableHead> {/* 時間列 */}
-            <TableHead className="hidden md:table-cell">内容</TableHead>{" "}
-            {/* 内容列 (PC版でのみ表示) */}
-            <TableHead className="text-right">アクション</TableHead>{" "}
-            {/* アクション列 (右寄せ) */}
+            <TableHead>タイトル</TableHead>
+            <TableHead>日付</TableHead>
+            <TableHead>時間</TableHead>
+            <TableHead className="hidden md:table-cell">内容</TableHead>
+            <TableHead className="text-right">アクション</TableHead>
           </TableRow>
         </TableHeader>
 
-        {/* テーブルの本体部分 */}
         <TableBody>
-          {/* 各学習記録の行をマッピングして表示 */}
           {records.map((record) => (
             <TableRow key={record.id}>
-              {/* タイトルセル - 学習記録のタイトル */}
               <TableCell className="font-medium">{record.title}</TableCell>
-
-              {/* 日付セル - 日付はフォーマットして表示 */}
               <TableCell>
-                {/* record.dateが有効な日付かをチェック */}
                 {record.date instanceof Date &&
                 !isNaN(record.date.getTime()) ? (
                   format(record.date, "yyyy/MM/dd", { locale: ja })
                 ) : (
-                  <span>無効な日付</span> // 無効な日付の場合は表示しない
+                  <span>無効な日付</span>
                 )}
               </TableCell>
 
-              {/* 時間セル - 開始時間と終了時間、そして学習時間 */}
               <TableCell>
                 {record.startTime} - {record.endTime}
                 <div className="text-xs text-muted-foreground">
@@ -75,27 +61,23 @@ const LearningRecordTable: React.FC<LearningRecordTableProps> = ({
                 </div>
               </TableCell>
 
-              {/* 内容セル - モバイルでは非表示、PC版で表示 */}
               <TableCell className="hidden md:table-cell max-w-xs truncate">
                 {record.content}
               </TableCell>
 
-              {/* アクションセル - 編集と削除ボタン */}
               <TableCell className="text-right">
                 <div className="flex justify-end gap-2">
-                  {/* 編集ボタン：青系 */}
                   <ActionButton
-                    onClick={() => handleEditRecord(record)} // 編集ボタンのクリック時にrecordを渡す
-                    icon={<Edit className="h-4 w-4" />} // 編集アイコン
-                    label="編集" // ボタンのラベル
-                    variant="outline" // 編集ボタンにはoutlineスタイル
+                    onClick={() => handleEditRecord(record)}
+                    icon={<Edit className="h-4 w-4" />}
+                    label="編集"
+                    variant="outline"
                   />
-                  {/* 削除ボタン：赤系 */}
                   <ActionButton
-                    onClick={() => handleDeleteRecord(record.id)} // 削除処理を呼び出す
-                    icon={<Trash className="h-4 w-4" />} // 削除アイコン
-                    label="削除" // ボタンのラベル
-                    variant="destructive" // 削除ボタンにはdestructiveスタイル
+                    onClick={() => handleDeleteRecord(record.id)}
+                    icon={<Trash className="h-4 w-4" />}
+                    label="削除"
+                    variant="destructive"
                   />
                 </div>
               </TableCell>

--- a/src/app/user/learning-history/_components/LearningRecordTable.tsx
+++ b/src/app/user/learning-history/_components/LearningRecordTable.tsx
@@ -8,10 +8,10 @@ import {
   TableHeader,
   TableRow,
   TableHead,
-} from "@ui/table";
-import { Edit, Trash } from "lucide-react";
-import { format } from "date-fns";
-import { ja } from "date-fns/locale";
+} from "@ui/table"; // UIコンポーネントのインポート
+import { Edit, Trash } from "lucide-react"; // 編集と削除アイコンのインポート
+import { format } from "date-fns"; // 日付のフォーマットを行うためのライブラリ
+import { ja } from "date-fns/locale"; // 日本語ロケールをインポート
 import { LearningRecord } from "@/app/_types/formTypes"; // 学習記録の型をインポート
 import "@components/ActionButton"; // ActionButtonコンポーネントをインポート
 import ActionButton from "@components/ActionButton"; // ActionButtonコンポーネントをインポート
@@ -20,24 +20,31 @@ import ActionButton from "@components/ActionButton"; // ActionButtonコンポー
 interface LearningRecordTableProps {
   records: LearningRecord[]; // 学習記録の配列
   handleDeleteRecord: (id: string) => void; // 削除処理を行う関数
+  handleEditRecord: (record: LearningRecord) => void; // 編集処理を行う関数
 }
 
 // 学習記録を表示するテーブルのコンポーネント
 const LearningRecordTable: React.FC<LearningRecordTableProps> = ({
   records, // 親コンポーネントから渡された学習記録
   handleDeleteRecord, // 削除用の関数
+  handleEditRecord, // 編集用の関数
 }) => {
+  // コンソールに取得したrecordsを表示
+  console.log("取得した学習記録:", records);
+
   return (
     <div className="rounded-md border">
       <Table>
         {/* テーブルのヘッダー部分 */}
         <TableHeader>
           <TableRow>
-            <TableHead>タイトル</TableHead>
-            <TableHead>日付</TableHead>
-            <TableHead>時間</TableHead>
-            <TableHead className="hidden md:table-cell">内容</TableHead>
-            <TableHead className="text-right">アクション</TableHead>
+            <TableHead>タイトル</TableHead> {/* タイトル列 */}
+            <TableHead>日付</TableHead> {/* 日付列 */}
+            <TableHead>時間</TableHead> {/* 時間列 */}
+            <TableHead className="hidden md:table-cell">内容</TableHead>{" "}
+            {/* 内容列 (PC版でのみ表示) */}
+            <TableHead className="text-right">アクション</TableHead>{" "}
+            {/* アクション列 (右寄せ) */}
           </TableRow>
         </TableHeader>
 
@@ -46,19 +53,25 @@ const LearningRecordTable: React.FC<LearningRecordTableProps> = ({
           {/* 各学習記録の行をマッピングして表示 */}
           {records.map((record) => (
             <TableRow key={record.id}>
-              {/* タイトルセル */}
+              {/* タイトルセル - 学習記録のタイトル */}
               <TableCell className="font-medium">{record.title}</TableCell>
 
               {/* 日付セル - 日付はフォーマットして表示 */}
               <TableCell>
-                {format(record.date, "yyyy/MM/dd", { locale: ja })}
+                {/* record.dateが有効な日付かをチェック */}
+                {record.date instanceof Date &&
+                !isNaN(record.date.getTime()) ? (
+                  format(record.date, "yyyy/MM/dd", { locale: ja })
+                ) : (
+                  <span>無効な日付</span> // 無効な日付の場合は表示しない
+                )}
               </TableCell>
 
               {/* 時間セル - 開始時間と終了時間、そして学習時間 */}
               <TableCell>
                 {record.startTime} - {record.endTime}
                 <div className="text-xs text-muted-foreground">
-                  {record.duration}
+                  {record.duration}時間
                 </div>
               </TableCell>
 
@@ -72,16 +85,16 @@ const LearningRecordTable: React.FC<LearningRecordTableProps> = ({
                 <div className="flex justify-end gap-2">
                   {/* 編集ボタン：青系 */}
                   <ActionButton
-                    onClick={() => {}}
-                    icon={<Edit className="h-4 w-4" />}
-                    label="編集"
+                    onClick={() => handleEditRecord(record)} // 編集ボタンのクリック時にrecordを渡す
+                    icon={<Edit className="h-4 w-4" />} // 編集アイコン
+                    label="編集" // ボタンのラベル
                     variant="outline" // 編集ボタンにはoutlineスタイル
                   />
                   {/* 削除ボタン：赤系 */}
                   <ActionButton
                     onClick={() => handleDeleteRecord(record.id)} // 削除処理を呼び出す
-                    icon={<Trash className="h-4 w-4" />}
-                    label="削除"
+                    icon={<Trash className="h-4 w-4" />} // 削除アイコン
+                    label="削除" // ボタンのラベル
                     variant="destructive" // 削除ボタンにはdestructiveスタイル
                   />
                 </div>

--- a/src/app/user/learning-history/page.tsx
+++ b/src/app/user/learning-history/page.tsx
@@ -82,8 +82,13 @@ const LearningHistory = () => {
   }, [user?.id]);
 
   useEffect(() => {
-    fetchLearningRecords(); // コンポーネントがマウントされたときに学習記録を取得
-  }, [fetchLearningRecords]); // fetchLearningRecords関数が変更されたときに実行されるようにする
+    // ユーザー情報が存在する場合のみfetchLearningRecordsを実行
+    if (user?.id) {
+      fetchLearningRecords();
+    } else {
+      console.log("ユーザー情報がまだ取得されていません");
+    }
+  }, [user?.id, fetchLearningRecords]); // user?.idが変わるたびに再実行// fetchLearningRecords関数が変更されたときに実行されるようにする
 
   const handleAddRecord = (record: LearningRecord) => {
     setRecords([record, ...records]); // 新しいレコードを配列の先頭に追加

--- a/src/app/user/learning-history/page.tsx
+++ b/src/app/user/learning-history/page.tsx
@@ -1,8 +1,8 @@
-// /src/app/user/learning-record/page.tsx
+// src/app/user/learning-history/page.tsx
 
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import AddRecordDialog from "./_components/AddRecordDialog";
 import Calendar from "./_components/Calendar";
 import LearningRecordTable from "./_components/LearningRecordTable";
@@ -13,100 +13,129 @@ import {
   CardHeader,
   CardTitle,
 } from "@/app/_components/ui/card";
-
 import { LearningRecord } from "@/app/_types/formTypes";
+import { useSession } from "@utils/session"; // セッション情報を取得
 
-// 仮の学習記録データ
-const initialRecords: LearningRecord[] = [
-  {
-    id: "1",
-    supabaseUserId: "sampleUserId",
-    categoryId: "1",
-    title: "CSS Grid レイアウト",
-    date: new Date("2023-03-18"),
-    startTime: "15:00",
-    endTime: "17:00",
-    duration: "2時間00分",
-    content: "複雑なグリッドレイアウトの実装方法",
-  },
-  {
-    id: "2",
-    supabaseUserId: "sampleUserId",
-    categoryId: "1",
-    title: "TypeScript 基礎",
-    date: new Date("2023-03-17"),
-    startTime: "10:00",
-    endTime: "12:30",
-    duration: "2時間30分",
-    content: "型定義とインターフェースについて学習",
-  },
-  {
-    id: "3",
-    supabaseUserId: "sampleUserId",
-    categoryId: "1",
-    title: "Next.js ルーティング",
-    date: new Date("2023-03-16"),
-    startTime: "14:00",
-    endTime: "16:30",
-    duration: "2時間30分",
-    content: "App Router の使い方を理解",
-  },
-  {
-    id: "4",
-    supabaseUserId: "sampleUserId",
-    categoryId: "1",
-    title: "React Hooks",
-    date: new Date("2023-03-15"),
-    startTime: "09:00",
-    endTime: "11:00",
-    duration: "2時間00分",
-    content: "useState と useEffect の基本を学習",
-  },
-];
+// 生データの型を定義
+interface RawRecord {
+  id: string;
+  supabaseUserId: string;
+  category: {
+    id: number;
+    category_name: string;
+  };
+  title: string;
+  learning_date: string; // ISO日付文字列
+  start_time: string; // ISO日付文字列
+  end_time: string; // ISO日付文字列
+  duration: number;
+  content: string;
+}
 
 const LearningHistory = () => {
-  const [records, setRecords] = useState<LearningRecord[]>(initialRecords);
+  const [records, setRecords] = useState<LearningRecord[]>([]); // 学習記録を格納するステート
+  const { user } = useSession(); // 現在のユーザーのセッション情報を取得
+
+  // 学習記録データを変換する関数
+  const transformRecord = (rawRecord: RawRecord): LearningRecord => {
+    return {
+      id: rawRecord.id, // idをstring型に変換
+      supabaseUserId: rawRecord.supabaseUserId,
+      categoryId: rawRecord.category.id, // カテゴリーIDを取得
+      title: rawRecord.title, // タイトルを取得
+      date: new Date(rawRecord.learning_date), // learning_dateをDate型に変換
+      startTime: rawRecord.start_time.split("T")[1].substring(0, 5), // 時間部分をHH:mm形式に変換
+      endTime: rawRecord.end_time.split("T")[1].substring(0, 5), // 時間部分をHH:mm形式に変換
+      duration: rawRecord.duration, // durationはそのまま使用
+      content: rawRecord.content,
+    };
+  };
+
+  // `supabaseUserId`に基づいてLearningRecordをフェッチする関数
+  const fetchLearningRecords = useCallback(async () => {
+    if (!user?.id) {
+      console.error("ユーザーIDが見つかりません");
+      return;
+    }
+
+    try {
+      const response = await fetch(
+        `/api/user/learning-history?supabaseUserId=${user.id}`
+      );
+
+      console.log("Fetch Learning Records Response:", response); // レスポンスのデバッグ用ログ
+      if (!response.ok) {
+        throw new Error("学習記録の取得に失敗しました");
+      }
+
+      const data: RawRecord[] = await response.json();
+
+      // データを変換してステートにセット
+      const transformedRecords = data.map((rawRecord) =>
+        transformRecord(rawRecord)
+      );
+      setRecords(transformedRecords); // 変換後のデータをステートにセット
+    } catch (error) {
+      console.error("学習記録の取得エラー:", error);
+      alert("学習記録の取得に失敗しました");
+    }
+  }, [user?.id]);
+
+  useEffect(() => {
+    fetchLearningRecords(); // コンポーネントがマウントされたときに学習記録を取得
+  }, [fetchLearningRecords]); // fetchLearningRecords関数が変更されたときに実行されるようにする
 
   const handleAddRecord = (record: LearningRecord) => {
-    setRecords([record, ...records]); // 新しいレコードを追加
+    setRecords([record, ...records]); // 新しいレコードを配列の先頭に追加
   };
 
   const handleDeleteRecord = (id: string) => {
-    setRecords(records.filter((record) => record.id !== id)); // レコードを削除
+    setRecords(records.filter((record) => record.id !== id)); // 指定されたIDのレコードを削除
+  };
+
+  // 編集機能（未実装）
+  const handleEditRecord = (record: LearningRecord) => {
+    console.log("Editing record with id:", record.id);
+    // 編集処理をここに追加する
   };
 
   const generateCalendarData = () => {
-    const today = new Date();
+    const today = new Date(); // 現在の日付を取得
     const weeks: {
       weekStart: Date;
       days: { date: Date; hasRecord: boolean }[];
     }[] = [];
     const currentDate = today;
 
+    // 2週間分のデータを生成
     for (let i = 0; i < 14; i++) {
       const week = [];
       for (let j = 0; j < 7; j++) {
         const date = new Date(currentDate);
-        const hasRecord = records.some(
-          (record) =>
-            date.getFullYear() === record.date.getFullYear() &&
-            date.getMonth() === record.date.getMonth() &&
-            date.getDate() === record.date.getDate()
-        );
+        const hasRecord = records.some((record) => {
+          if (record.date) {
+            return (
+              date.getFullYear() === record.date.getFullYear() &&
+              date.getMonth() === record.date.getMonth() &&
+              date.getDate() === record.date.getDate()
+            );
+          }
+          return false; // record.dateが無効な場合はfalseを返す
+        });
         week.push({ date, hasRecord });
-        currentDate.setDate(currentDate.getDate() + 1);
+        currentDate.setDate(currentDate.getDate() + 1); // 日付を1日進める
       }
       weeks.push({ weekStart: currentDate, days: week });
     }
 
     // 左右にカレンダーを分割
-    const leftCalendar = weeks.slice(0, 7);
-    const rightCalendar = weeks.slice(7, 14);
+    const leftCalendar = weeks.slice(0, 7); // 左側のカレンダー（1週間分）
+    const rightCalendar = weeks.slice(7, 14); // 右側のカレンダー（残りの1週間分）
 
     return { leftCalendar, rightCalendar };
   };
 
-  const { leftCalendar, rightCalendar } = generateCalendarData();
+  const { leftCalendar, rightCalendar } = generateCalendarData(); // カレンダー用データを取得
 
   return (
     <div className="space-y-6">
@@ -133,6 +162,7 @@ const LearningHistory = () => {
       <LearningRecordTable
         records={records}
         handleDeleteRecord={handleDeleteRecord}
+        handleEditRecord={handleEditRecord} // 編集機能を渡す
       />
     </div>
   );


### PR DESCRIPTION
# 学習記録の追加機能実装

## 概要
このプルリクエストでは、ユーザーが新しい学習記録を追加するためのダイアログフォームを実装しました。フォームには以下の項目があります：
- タイトル
- 日付
- 開始時間
- 終了時間
- 内容
- カテゴリー

## 変更点
1. **AddRecordDialogコンポーネントの作成**
   - 学習記録を入力するダイアログを実装しました。
   - フォーム入力に応じて、学習記録を作成するための`handleSubmit`関数を追加しました。
   - 入力されたデータは、サーバーにPOSTリクエストを送信し、データベースに保存されます。

2. **カテゴリーの取得**
   - 学習記録のカテゴリーをサーバーから取得するため、`fetchCategories`関数を使用して、カテゴリーの一覧を表示できるようにしました。
   - カテゴリーは選択肢として`select`タグで表示され、ユーザーはその中から選ぶことができます。

3. **送信後の処理**
   - 新しい学習記録が正常に送信されると、親コンポーネントに新しいレコードが追加され、ダイアログが閉じます。
   - 学習記録の追加に成功した場合は、フォームの内容がリセットされます。

4. **アクセシビリティの向上**
   - ダイアログに`aria-describedby`を追加して、スクリーンリーダーで説明が読み上げられるようにしました。

## 追加されたファイル
- `src/app/user/learning-history/_components/AddRecordDialog.tsx`: 学習記録追加用のダイアログフォームコンポーネント
- `src/app/_types/formTypes.ts`: 学習記録とカテゴリーの型定義

## 実装の詳細
- ユーザーが「学習記録を追加」ボタンをクリックすると、ダイアログが表示されます。
- ユーザーがフォームに必要な情報（タイトル、日付、時間、内容、カテゴリー）を入力後、「追加」ボタンを押すことで学習記録が追加されます。
- 学習記録がサーバーに送信され、成功した場合、状態が更新されて新しい学習記録がリストに追加されます。

## 影響範囲
- 学習記録の追加に関連するコンポーネント（`LearningHistory`, `LearningRecordTable`）が更新されました。
- フォームに必要なフィールドが追加され、バリデーション機能が強化されています。

## テスト手順
1. 学習記録一覧ページ（`/user/learning-history`）に移動します。
2. 「学習記録を追加」ボタンをクリックします。
3. ダイアログフォームが表示されるので、必要な情報を入力します。
4. 「追加」ボタンを押すと、学習記録が追加され、リストに表示されることを確認します。

## スクリーンショット
<img width="934" alt="スクリーンショット 2025-04-09 15 46 20" src="https://github.com/user-attachments/assets/4a70f3e8-45d4-433c-8db9-cbf6bf51fb02" />

<img width="384" alt="スクリーンショット 2025-04-09 15 46 28" src="https://github.com/user-attachments/assets/83bd3a2f-5336-4222-9578-4f4140d9afad" />

