### PR TITLE
Add FormField Component Types to formTypes.ts

### DIFF
--- a/src/app/_types/formTypes.ts
+++ b/src/app/_types/formTypes.ts
@@ -11,20 +11,20 @@ export type SignUpFormData = {
   nickname: string; // ユーザーのニックネーム
   email: string; // ユーザーのメールアドレス
   password: string; // ユーザーのパスワード
-  confirmPassword: string; // パスワード確認用
+  confirmPassword: string; // パスワード確認用（パスワードの再入力）
 };
 
 // 学習記録に関連する型
 export type LearningRecord = {
-  supabaseUserId: string; // ユーザーのSupabase ID
+  supabaseUserId: string; // ユーザーのSupabase ID（学習記録が関連付けられているユーザーのID）
   categoryId: number; // 学習記録のカテゴリーID
   id: string; // 学習記録のID
   title: string; // 学習記録のタイトル
-  date: Date; // 学習日付（Date型）
-  startTime: string; // 学習開始時間（HH:mm形式）
-  endTime: string; // 学習終了時間（HH:mm形式）
-  duration: number; // 学習時間（時間単位）
-  content: string; // 学習内容
+  date: Date; // 学習日付（Date型、学習が行われた日）
+  startTime: string; // 学習開始時間（HH:mm形式、学習が開始した時間）
+  endTime: string; // 学習終了時間（HH:mm形式、学習が終了した時間）
+  duration: number; // 学習時間（時間単位、学習に費やした時間）
+  content: string; // 学習内容（学習した内容）
 };
 
 // ユーザーのプロフィールに関連する型
@@ -33,44 +33,53 @@ export type UserProfile = {
   first_name: string; // ユーザーの姓
   last_name: string; // ユーザーの名
   gender?: string; // 性別（任意、'男', '女', 'その他'など）
-  bio?: string; // 自己紹介（任意）
-  phoneNumber?: string; // 電話番号（任意）
-  socialLinks?: string; // SNSリンク（任意）
-  pushNotifications: boolean; // プッシュ通知の有効化（true or false）
-  date_of_birth?: string; // 生年月日（任意）
-  profile_picture?: string; // プロフィール画像URL（任意）
+  bio?: string; // 自己紹介（任意、ユーザーが自己紹介を追加できる）
+  phoneNumber?: string; // 電話番号（任意、ユーザーの電話番号）
+  socialLinks?: string; // SNSリンク（任意、ユーザーのSNSアカウント）
+  pushNotifications: boolean; // プッシュ通知の有効化（trueまたはfalse）
+  date_of_birth?: string; // 生年月日（任意、ユーザーの生年月日）
+  profile_picture?: string; // プロフィール画像URL（任意、ユーザーのプロフィール画像）
 };
 
 // 学習記録のカテゴリーに関連する型
 export interface Category {
-  id: number; // カテゴリーID
-  category_name: string; // カテゴリー名
+  id: number; // カテゴリーID（カテゴリーの一意な識別子）
+  category_name: string; // カテゴリー名（例: "プログラミング", "数学" など）
 }
 
 // 生データの型を定義（APIなどから取得する元データに対応）
 export interface RawRecord {
   id: string; // 学習記録のID
-  supabaseUserId: string; // ユーザーのSupabase ID
+  supabaseUserId: string; // ユーザーのSupabase ID（学習記録が関連付けられているユーザーのID）
   category: {
-    id: number; // カテゴリーID
-    category_name: string; // カテゴリー名
+    id: number; // カテゴリーID（学習記録のカテゴリーID）
+    category_name: string; // カテゴリー名（学習記録のカテゴリー名）
   };
   title: string; // 学習記録のタイトル
-  learning_date: string; // 学習日付（ISO日付文字列）
-  start_time: string; // 学習開始時間（ISO日付文字列）
-  end_time: string; // 学習終了時間（ISO日付文字列）
-  duration: number; // 学習時間
-  content: string; // 学習内容
+  learning_date: string; // 学習日付（ISO形式の日付文字列）
+  start_time: string; // 学習開始時間（ISO形式の時間文字列）
+  end_time: string; // 学習終了時間（ISO形式の時間文字列）
+  duration: number; // 学習時間（学習時間）
+  content: string; // 学習内容（学習した内容の詳細）
 }
 
 // 学習記録ダイアログのプロパティ型
 export interface LearningRecordDialogProps {
-  onAddRecord: (record: LearningRecord) => void;
-  onSaveRecord: (record: LearningRecord) => void;
-  onDeleteRecord: (id: string) => void;
-  recordToEdit: LearningRecord | null; // 編集対象のレコード
-  isEditing: boolean; // 編集モードかどうか
-  refreshRecords: () => void; // 学習記録更新後に再フェッチ
-  open: boolean; // ダイアログの開閉状態
+  onAddRecord: (record: LearningRecord) => void; // 新しい学習記録を追加するための関数
+  onSaveRecord: (record: LearningRecord) => void; // 既存の学習記録を保存するための関数
+  onDeleteRecord: (id: string) => void; // 学習記録を削除するための関数
+  recordToEdit: LearningRecord | null; // 編集する学習記録（nullの場合は新規作成）
+  isEditing: boolean; // 編集モードかどうかを示すフラグ
+  refreshRecords: () => void; // 学習記録更新後に再フェッチするための関数
+  open: boolean; // ダイアログの開閉状態を示すフラグ
   setOpen: (open: boolean) => void; // ダイアログの開閉を制御する関数
+}
+
+// フォームフィールドの型
+export interface FormFieldProps {
+  label: string; // フィールドのラベル（例: "タイトル", "内容" など）
+  id: string; // 各入力フィールドのID
+  value: string; // フィールドの現在の値
+  onChange: (value: string) => void; // 値が変更された際に呼ばれる関数
+  type: string; // 入力のタイプ（"text", "textarea", "date", "time" など）
 }

--- a/src/app/user/learning-history/_components/FormField.tsx
+++ b/src/app/user/learning-history/_components/FormField.tsx
@@ -2,16 +2,7 @@ import React from "react";
 import { Input } from "@ui/input";
 import { Label } from "@ui/label";
 import { Textarea } from "@ui/textarea";
-
-// フォームフィールドを汎用化したコンポーネント
-// ラベル、入力値、変更関数、入力タイプを受け取る
-interface FormFieldProps {
-  label: string; // フィールドのラベル（例: "タイトル", "内容" など）
-  id: string; // 各入力フィールドのID
-  value: string; // フィールドの現在の値
-  onChange: (value: string) => void; // 値が変更された際に呼ばれる関数
-  type: string; // 入力のタイプ（"text", "textarea", "date", "time" など）
-}
+import { FormFieldProps } from "@/app/_types/formTypes";
 
 // 汎用的なフォームフィールドコンポーネント
 // テキスト入力またはテキストエリアの形式で表示される


### PR DESCRIPTION
## 概要

`formTypes.ts` にフォームフィールドコンポーネント用の型を追加しました。この変更により、フォームフィールドを汎用的に管理できるようになり、型安全が向上します。

## 変更内容

- `formTypes.ts` に `FormFieldProps` 型を追加
  - フィールドのラベル、ID、現在の値、変更関数、入力タイプを管理するための型です。
- 各フォームフィールドコンポーネント（テキスト入力、テキストエリア、日付など）の型を統一的に管理

## 目的

- フォームフィールドの管理を効率化
- 型安全を強化
- 他のコンポーネントでも再利用可能な型を提供

## 変更理由

フォームフィールドに関連する型定義を一元管理することで、コードの可読性と保守性が向上し、他のコンポーネントでも再利用しやすくなります。

## 影響範囲

- `formTypes.ts` に新しい型が追加されます。
- 他のコンポーネントでフォームフィールドに関連する型を使用している場合、そのコードを更新する必要があります。

## 今後の対応

- 他のコンポーネントでの型利用を進める
- 必要に応じて、フォームコンポーネントの追加・修正を行う


- Closes #20