### PR TITLE
＃30 カテゴリ別学習時間の連携

### DIFF
--- a/src/app/_utils/fetcher.ts
+++ b/src/app/_utils/fetcher.ts
@@ -1,0 +1,7 @@
+// フェッチ関数（共通）
+
+export const fetcher = (url: string) =>
+  fetch(url).then((res) => {
+    if (!res.ok) throw new Error("API error");
+    return res.json();
+  });

--- a/src/app/api/user/category-distribution/route.ts
+++ b/src/app/api/user/category-distribution/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+export async function GET(req: NextRequest) {
+  const supabaseUserId = req.nextUrl.searchParams.get("supabaseUserId");
+
+  if (!supabaseUserId) {
+    return NextResponse.json({ error: "No user ID provided" }, { status: 400 });
+  }
+
+  // カテゴリごとの学習時間を集計
+  const records = await prisma.learningRecord.groupBy({
+    by: ["categoryId"],
+    where: { supabaseUserId },
+    _sum: { duration: true },
+  });
+
+  // カテゴリIDごとに名前を取得
+  const categories = await prisma.category.findMany();
+
+  const labels: string[] = [];
+  const data: number[] = [];
+
+  records.forEach((record) => {
+    const category = categories.find((c) => c.id === record.categoryId);
+    if (category) {
+      labels.push(category.category_name);
+      data.push(record._sum.duration ?? 0);
+    }
+  });
+
+  return NextResponse.json({ labels, data });
+}

--- a/src/app/user/dashboard/page.tsx
+++ b/src/app/user/dashboard/page.tsx
@@ -2,22 +2,24 @@
 
 import { useState } from "react";
 import useSWR from "swr";
-import { useSession } from "@utils/session"; // Supabase セッション情報を取得
+import { useSession } from "@utils/session";
 import DashboardHeader from "@/app/user/dashboard/_components/DashboardHeader";
 import DashboardStats from "@/app/user/dashboard/_components/DashboardStats";
 import WeeklyCharts from "@/app/user/dashboard/_components/WeeklyCharts";
 import HeatmapSection from "@/app/user/dashboard/_components/HeatmapSection";
 import RecentRecords from "@/app/user/dashboard/_components/RecentRecords";
 import MonthlyGoals from "@/app/user/dashboard/_components/MonthlyGoals";
-
-// API フェッチ用の関数
-const fetcher = (url: string) => fetch(url).then((res) => res.json());
+import { fetcher } from "@utils/fetcher";
 
 export default function Home() {
-  // 認証済みユーザー情報を取得
+  // -----------------------------
+  // 認証済みユーザー情報の取得
+  // -----------------------------
   const { user } = useSession();
 
-  // 今週と先週の学習時間データを取得
+  // -----------------------------
+  // 今週と先週の合計学習時間を取得（棒グラフ概要・差分表示用）
+  // -----------------------------
   const { data } = useSWR(
     user?.supabaseUserId
       ? `/api/user/weekly-learning-duration?supabaseUserId=${user.supabaseUserId}`
@@ -25,19 +27,19 @@ export default function Home() {
     fetcher
   );
 
-  // 今週と先週の合計学習時間（0がデフォルト）
   const weeklyDuration = data?.weeklyDuration ?? 0;
   const lastWeekDuration = data?.lastWeekDuration ?? 0;
 
-  // 差分の計算とテキスト生成
+  // 差分の計算・テキスト化
   const diff = weeklyDuration - lastWeekDuration;
   const diffText =
     diff === 0
       ? "先週と同じ"
       : `先週比 ${diff > 0 ? "+" : ""}${diff.toFixed(1)}時間`;
 
-  // 週間チャート用のダミーデータ
-  // 今週の曜日別学習時間（棒グラフ用）を取得
+  // -----------------------------
+  // 曜日別の週間学習データを取得（棒グラフ用）
+  // -----------------------------
   const { data: weeklyChart } = useSWR(
     user?.supabaseUserId
       ? `/api/user/weekly-chart-data?supabaseUserId=${user.supabaseUserId}`
@@ -45,7 +47,7 @@ export default function Home() {
     fetcher
   );
 
-  // SWRから取得した棒グラフ用データを Chart.js 形式に変換
+  // 取得データを Chart.js 形式に整形（未取得時は初期値でフォールバック）
   const chartData = weeklyChart
     ? {
         labels: weeklyChart.labels,
@@ -70,34 +72,55 @@ export default function Home() {
 
   console.log("📊 週間チャートデータ:", chartData);
 
-  // カテゴリ別円グラフのダミーデータ
-  const categoryData = {
-    labels: ["プログラミング", "語学", "数学", "科学", "歴史"],
-    datasets: [
-      {
-        data: [30, 20, 15, 25, 10], // ダミー値
-        backgroundColor: [
-          "rgba(255, 99, 132, 0.6)",
-          "rgba(54, 162, 235, 0.6)",
-          "rgba(255, 206, 86, 0.6)",
-          "rgba(75, 192, 192, 0.6)",
-          "rgba(153, 102, 255, 0.6)",
-        ],
-      },
-    ],
-  };
+  // -----------------------------
+  // カテゴリ別学習時間を取得（円グラフ用）
+  // -----------------------------
+  const { data: categoryRaw } = useSWR(
+    user?.supabaseUserId
+      ? `/api/user/category-distribution?supabaseUserId=${user.supabaseUserId}`
+      : null,
+    fetcher
+  );
 
-  // ヒートマップ用のランダムな90日分データ
+  // カテゴリ別データを Chart.js 形式に整形（未取得時は空データ）
+  const categoryData = categoryRaw
+    ? {
+        labels: categoryRaw.labels,
+        datasets: [
+          {
+            data: categoryRaw.data,
+            backgroundColor: [
+              "rgba(255, 99, 132, 0.6)",
+              "rgba(54, 162, 235, 0.6)",
+              "rgba(255, 206, 86, 0.6)",
+              "rgba(75, 192, 192, 0.6)",
+              "rgba(153, 102, 255, 0.6)",
+            ],
+          },
+        ],
+      }
+    : {
+        labels: [],
+        datasets: [{ data: [], backgroundColor: [] }],
+      };
+
+  console.log("📊 カテゴリ別データ:", categoryData);
+
+  // -----------------------------
+  // ヒートマップ表示用の仮データ（直近90日間の学習量）
+  // -----------------------------
   const [heatmapData] = useState(() => {
     const today = new Date();
     return Array.from({ length: 90 }, (_, i) => {
       const date = new Date(today);
       date.setDate(date.getDate() - i);
-      return { date, hours: Math.random() * 5 }; // 0〜5時間の範囲でランダム生成
+      return { date, hours: Math.random() * 5 };
     });
   });
 
-  // ダッシュボードUIの描画
+  // -----------------------------
+  // ダッシュボード表示UI
+  // -----------------------------
   return (
     <div className="space-y-6">
       <DashboardHeader />


### PR DESCRIPTION
## 概要

ユーザーが記録した学習データをカテゴリごとに集計し、ダッシュボード上の円グラフ（CategoryChart）で可視化できるようにしました。

---

## 対応内容

- `GET /api/user/category-distribution` エンドポイントを新規実装  
  - 指定された `supabaseUserId` に基づき、カテゴリごとの合計学習時間を集計
  - 対応するカテゴリ名とともにラベル・データとして返却
  - レスポンス例：
    ```json
    {
      "labels": ["プログラミング", "数学", "語学"],
      "data": [12.5, 8.0, 5.5]
    }
    ```

- `Home.tsx` にて SWR を使って API からカテゴリ別データを取得

- `WeeklyCharts` コンポーネントに `categoryData` を props で渡して `CategoryChart` を描画

- ダミーデータを削除し、実データに基づく円グラフ表示に置き換え

---

## 補足

- カテゴリ色は一旦固定カラーを使用していますが、今後ランダム生成やカテゴリごとのテーマ色への拡張も検討可能です
- 学習記録がない場合は空グラフとして描画されます（初期化済）

---

## 関連Issue

- close #30
