### PR TITLE
#31 HeatmapCalendar のバックエンド連携

### DIFF
--- a/src/app/_components/heatmap-calendar.tsx
+++ b/src/app/_components/heatmap-calendar.tsx
@@ -1,106 +1,136 @@
-"use client"
-import { format, subDays, isSameDay, startOfWeek, addDays } from "date-fns"
-import React from "react"
+"use client";
 
-import { ja } from "date-fns/locale"
+import { format, subDays, isSameDay, startOfWeek, addDays } from "date-fns";
+import React from "react";
+import { ja } from "date-fns/locale";
 
+// -----------------------------
+// Props 型定義
+// -----------------------------
 interface HeatmapCalendarProps {
   data: {
-    date: Date
-    hours: number
-  }[]
+    date: Date;
+    hours: number;
+  }[];
 }
 
+// -----------------------------
+// ヒートマップカレンダーコンポーネント
+// -----------------------------
 export function HeatmapCalendar({ data }: HeatmapCalendarProps) {
-  const today = new Date()
-  const threeMonthsAgo = subDays(today, 90)
-  const startDate = startOfWeek(threeMonthsAgo, { weekStartsOn: 1 }) // 月曜日から開始
+  const today = new Date();
+  const threeMonthsAgo = subDays(today, 90);
 
+  // 90日前の週の月曜日から表示開始
+  const startDate = startOfWeek(threeMonthsAgo, { weekStartsOn: 1 });
+
+  // -----------------------------
+  // 学習時間に応じた色を返す関数
+  // -----------------------------
   const getIntensity = (hours: number) => {
-    if (hours === 0) return "bg-gray-100"
-    if (hours < 1) return "bg-pink-100"
-    if (hours < 2) return "bg-pink-200"
-    if (hours < 3) return "bg-pink-300"
-    if (hours < 4) return "bg-pink-400"
-    return "bg-pink-500"
-  }
+    if (hours === 0) return "bg-gray-100"; // 学習なし
+    if (hours < 2) return "bg-pink-100"; // ～2時間
+    if (hours < 4) return "bg-pink-200"; // ～4時間
+    if (hours < 6) return "bg-pink-300"; // ～6時間
+    if (hours < 8) return "bg-pink-400"; // ～8時間
+    return "bg-pink-500"; // それ以上
+  };
 
-  // 週ごとのデータを生成
-  const weeks = []
-  let currentDate = startDate
+  // -----------------------------
+  // 表示用に週単位で日付を構造化
+  // -----------------------------
+  const weeks = [];
+  let currentDate = startDate;
 
   while (currentDate <= today) {
-    const week = []
+    const week = [];
     for (let i = 0; i < 7; i++) {
-      week.push(currentDate)
-      currentDate = addDays(currentDate, 1)
+      week.push(currentDate);
+      currentDate = addDays(currentDate, 1);
     }
-    weeks.push(week)
+    weeks.push(week);
   }
 
-  // 2列に分割
-  const halfLength = Math.ceil(weeks.length / 2)
-  const leftColumn = weeks.slice(0, halfLength)
-  const rightColumn = weeks.slice(halfLength)
+  // 表示の都合で2列に分割
+  const halfLength = Math.ceil(weeks.length / 2);
+  const leftColumn = weeks.slice(0, halfLength);
+  const rightColumn = weeks.slice(halfLength);
 
   return (
     <div className="flex flex-col md:flex-row gap-8">
-      {/* 左列 */}
+      {/* ---------- 左列 ---------- */}
       <div className="flex-1">
         <div className="grid grid-cols-[auto_repeat(7,1fr)] gap-1">
-          <div className="h-6" /> {/* 日付ラベル用の空白 */}
+          {/* 曜日ラベル */}
+          <div className="h-6" />
           {["月", "火", "水", "木", "金", "土", "日"].map((day, i) => (
             <div key={i} className="h-6 text-xs text-gray-500 text-center">
               {day}
             </div>
           ))}
+
+          {/* 各週・各日表示 */}
           {leftColumn.map((week, weekIndex) => (
             <React.Fragment key={weekIndex}>
-              <div className="text-xs text-gray-500 pr-2 text-right">{format(week[0], "M/d", { locale: ja })}</div>
+              <div className="text-xs text-gray-500 pr-2 text-right">
+                {format(week[0], "M/d", { locale: ja })}
+              </div>
               {week.map((day, dayIndex) => {
-                const dayData = data.find((d) => isSameDay(d.date, day))
-                const hours = dayData ? dayData.hours : 0
+                const dayData = data.find((d) => isSameDay(d.date, day));
+                const hours = dayData ? dayData.hours : 0;
                 return (
                   <div
                     key={dayIndex}
-                    className={`aspect-square ${getIntensity(hours)} rounded-sm transition-colors duration-200 hover:opacity-80`}
-                    title={`${format(day, "yyyy/MM/dd")}: ${hours.toFixed(1)}時間`}
+                    className={`aspect-square ${getIntensity(
+                      hours
+                    )} rounded-sm transition-colors duration-200 hover:opacity-80`}
+                    title={`${format(day, "yyyy/MM/dd")}: ${hours.toFixed(
+                      1
+                    )}時間`}
                   />
-                )
+                );
               })}
             </React.Fragment>
           ))}
         </div>
       </div>
 
-      {/* 右列 */}
+      {/* ---------- 右列 ---------- */}
       <div className="flex-1">
         <div className="grid grid-cols-[auto_repeat(7,1fr)] gap-1">
-          <div className="h-6" /> {/* 日付ラベル用の空白 */}
+          {/* 曜日ラベル */}
+          <div className="h-6" />
           {["月", "火", "水", "木", "金", "土", "日"].map((day, i) => (
             <div key={i} className="h-6 text-xs text-gray-500 text-center">
               {day}
             </div>
           ))}
+
+          {/* 各週・各日表示 */}
           {rightColumn.map((week, weekIndex) => (
             <React.Fragment key={weekIndex}>
-              <div className="text-xs text-gray-500 pr-2 text-right">{format(week[0], "M/d", { locale: ja })}</div>
+              <div className="text-xs text-gray-500 pr-2 text-right">
+                {format(week[0], "M/d", { locale: ja })}
+              </div>
               {week.map((day, dayIndex) => {
-                const dayData = data.find((d) => isSameDay(d.date, day))
-                const hours = dayData ? dayData.hours : 0
+                const dayData = data.find((d) => isSameDay(d.date, day));
+                const hours = dayData ? dayData.hours : 0;
                 return (
                   <div
                     key={dayIndex}
-                    className={`aspect-square ${getIntensity(hours)} rounded-sm transition-colors duration-200 hover:opacity-80`}
-                    title={`${format(day, "yyyy/MM/dd")}: ${hours.toFixed(1)}時間`}
+                    className={`aspect-square ${getIntensity(
+                      hours
+                    )} rounded-sm transition-colors duration-200 hover:opacity-80`}
+                    title={`${format(day, "yyyy/MM/dd")}: ${hours.toFixed(
+                      1
+                    )}時間`}
                   />
-                )
+                );
               })}
             </React.Fragment>
           ))}
         </div>
       </div>
     </div>
-  )
+  );
 }
-

--- a/src/app/api/user/heatmap/route.ts
+++ b/src/app/api/user/heatmap/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+import { PrismaClient } from "@prisma/client";
+import { format, subDays } from "date-fns";
+
+const prisma = new PrismaClient();
+
+export async function GET(req: NextRequest) {
+  // クエリパラメータから supabaseUserId を取得
+  const supabaseUserId = req.nextUrl.searchParams.get("supabaseUserId");
+
+  // ユーザーIDが指定されていない場合は 400 エラーを返す
+  if (!supabaseUserId) {
+    return NextResponse.json({ error: "No user ID provided" }, { status: 400 });
+  }
+
+  // 現在日付と90日前の開始日を取得（今日を含めて90日分）
+  const today = new Date();
+  const startDate = subDays(today, 89); // 90日前（今日含む）
+
+  // 指定されたユーザーの過去90日間の学習記録を取得
+  const records = await prisma.learningRecord.findMany({
+    where: {
+      supabaseUserId,
+      learning_date: {
+        gte: startDate, // 90日前以降
+        lte: today, // 今日まで
+      },
+    },
+    select: {
+      learning_date: true, // 学習日
+      duration: true, // 学習時間
+    },
+  });
+
+  // 日別に学習時間を合計するためのマップを初期化
+  const totals: Record<string, number> = {};
+
+  // 各レコードの日付をキーとして学習時間を集計
+  records.forEach((record) => {
+    const dateStr = format(record.learning_date, "yyyy-MM-dd");
+    totals[dateStr] = (totals[dateStr] ?? 0) + record.duration;
+  });
+
+  // 90日分すべての日付を走査し、学習時間を埋める（なければ0）
+  const response = Array.from({ length: 90 }, (_, i) => {
+    const date = subDays(today, i);
+    const dateStr = format(date, "yyyy-MM-dd");
+    return {
+      date: dateStr, // 文字列形式の日付
+      hours: totals[dateStr] ?? 0, // 学習時間（なければ 0）
+    };
+  });
+
+  // JSON形式でレスポンスを返却
+  return NextResponse.json(response);
+}

--- a/src/app/user/dashboard/page.tsx
+++ b/src/app/user/dashboard/page.tsx
@@ -1,25 +1,25 @@
 "use client";
 
-import { useState } from "react";
+// 必要なHooksやコンポーネントをインポート
 import useSWR from "swr";
-import { useSession } from "@utils/session";
+import { useSession } from "@utils/session"; // 認証済みユーザー情報の取得
 import DashboardHeader from "@/app/user/dashboard/_components/DashboardHeader";
 import DashboardStats from "@/app/user/dashboard/_components/DashboardStats";
 import WeeklyCharts from "@/app/user/dashboard/_components/WeeklyCharts";
 import HeatmapSection from "@/app/user/dashboard/_components/HeatmapSection";
 import RecentRecords from "@/app/user/dashboard/_components/RecentRecords";
 import MonthlyGoals from "@/app/user/dashboard/_components/MonthlyGoals";
-import { fetcher } from "@utils/fetcher";
+import { fetcher } from "@utils/fetcher"; // 共通のデータフェッチ関数
 
 export default function Home() {
-  // -----------------------------
+  // -------------------------------
   // 認証済みユーザー情報の取得
-  // -----------------------------
+  // -------------------------------
   const { user } = useSession();
 
-  // -----------------------------
-  // 今週と先週の合計学習時間を取得（棒グラフ概要・差分表示用）
-  // -----------------------------
+  // -------------------------------
+  // 今週と先週の合計学習時間データを取得
+  // -------------------------------
   const { data } = useSWR(
     user?.supabaseUserId
       ? `/api/user/weekly-learning-duration?supabaseUserId=${user.supabaseUserId}`
@@ -27,19 +27,20 @@ export default function Home() {
     fetcher
   );
 
+  // デフォルトは 0 時間
   const weeklyDuration = data?.weeklyDuration ?? 0;
   const lastWeekDuration = data?.lastWeekDuration ?? 0;
 
-  // 差分の計算・テキスト化
+  // 差分テキスト生成（±表示）
   const diff = weeklyDuration - lastWeekDuration;
   const diffText =
     diff === 0
       ? "先週と同じ"
       : `先週比 ${diff > 0 ? "+" : ""}${diff.toFixed(1)}時間`;
 
-  // -----------------------------
-  // 曜日別の週間学習データを取得（棒グラフ用）
-  // -----------------------------
+  // -------------------------------
+  // 曜日別の週間学習時間データを取得（棒グラフ用）
+  // -------------------------------
   const { data: weeklyChart } = useSWR(
     user?.supabaseUserId
       ? `/api/user/weekly-chart-data?supabaseUserId=${user.supabaseUserId}`
@@ -47,7 +48,7 @@ export default function Home() {
     fetcher
   );
 
-  // 取得データを Chart.js 形式に整形（未取得時は初期値でフォールバック）
+  // Chart.js 形式に整形（未取得時は初期値）
   const chartData = weeklyChart
     ? {
         labels: weeklyChart.labels,
@@ -72,9 +73,9 @@ export default function Home() {
 
   console.log("📊 週間チャートデータ:", chartData);
 
-  // -----------------------------
-  // カテゴリ別学習時間を取得（円グラフ用）
-  // -----------------------------
+  // -------------------------------
+  // カテゴリ別学習時間データを取得（円グラフ用）
+  // -------------------------------
   const { data: categoryRaw } = useSWR(
     user?.supabaseUserId
       ? `/api/user/category-distribution?supabaseUserId=${user.supabaseUserId}`
@@ -82,7 +83,7 @@ export default function Home() {
     fetcher
   );
 
-  // カテゴリ別データを Chart.js 形式に整形（未取得時は空データ）
+  // Chart.js 形式に整形（未取得時は空）
   const categoryData = categoryRaw
     ? {
         labels: categoryRaw.labels,
@@ -106,27 +107,36 @@ export default function Home() {
 
   console.log("📊 カテゴリ別データ:", categoryData);
 
-  // -----------------------------
-  // ヒートマップ表示用の仮データ（直近90日間の学習量）
-  // -----------------------------
-  const [heatmapData] = useState(() => {
-    const today = new Date();
-    return Array.from({ length: 90 }, (_, i) => {
-      const date = new Date(today);
-      date.setDate(date.getDate() - i);
-      return { date, hours: Math.random() * 5 };
-    });
-  });
+  // -------------------------------
+  // ヒートマップ用データを取得（直近90日分）
+  // -------------------------------
+  const { data: heatmapData } = useSWR(
+    user?.supabaseUserId
+      ? `/api/user/heatmap?supabaseUserId=${user.supabaseUserId}`
+      : null,
+    fetcher
+  );
 
-  // -----------------------------
-  // ダッシュボード表示UI
-  // -----------------------------
+  console.log("🔥 ヒートマップデータ:", heatmapData);
+
+  // -------------------------------
+  // ダッシュボードの描画
+  // -------------------------------
   return (
     <div className="space-y-6">
+      {/* ヘッダー */}
       <DashboardHeader />
+
+      {/* 今週の統計（合計時間・差分） */}
       <DashboardStats weeklyDuration={weeklyDuration} diffText={diffText} />
+
+      {/* チャート：棒グラフと円グラフ */}
       <WeeklyCharts chartData={chartData} categoryData={categoryData} />
-      <HeatmapSection data={heatmapData} />
+
+      {/* ヒートマップ（直近90日） */}
+      <HeatmapSection data={heatmapData ?? []} />
+
+      {/* 最近の記録 & 今月の目標 */}
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
         <RecentRecords />
         <MonthlyGoals />


### PR DESCRIPTION
## 概要
ユーザーの直近90日間（約3ヶ月間）の学習時間を日別で取得し、ヒートマップ形式で可視化できるようにしました。

Closes #31

---

## 対応内容

- `GET /api/user/heatmap` エンドポイントを新規実装  
  - 指定された `supabaseUserId` に対して、90日分の学習記録を取得  
  - 日付ごとに `duration` を合計し、日別データとして整形して返却

- `Dashboard` ページにて、`useSWR` を用いて `heatmap` データを取得し、`HeatmapSection` コンポーネントに渡して描画

- フロントエンドでは `date`（yyyy-MM-dd）と `hours`（学習時間）を元に、該当日付の学習量を可視化するヒートマップを構築

---

## APIエンドポイント仕様

- **URL**: `/api/user/heatmap`
- **メソッド**: `GET`
- **クエリパラメータ**:
  - `supabaseUserId`: ユーザーの Supabase ID

- **レスポンス例**:

```json
[
  { "date": "2024-12-01", "hours": 1.5 },
  { "date": "2024-12-02", "hours": 0 },
  ...
]
