### PR TITLE
#32 最近の学習記録の取得

### DIFF
--- a/src/app/api/user/recent-learning-records/route.ts
+++ b/src/app/api/user/recent-learning-records/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+import { PrismaClient } from "@prisma/client";
+import { formatDistanceToNow } from "date-fns";
+import { ja } from "date-fns/locale";
+
+// Prisma クライアントのインスタンスを作成
+const prisma = new PrismaClient();
+
+// GET リクエストの処理
+export async function GET(req: NextRequest) {
+  // クエリパラメータから supabaseUserId を取得
+  const supabaseUserId = req.nextUrl.searchParams.get("supabaseUserId");
+
+  // supabaseUserId が指定されていない場合はエラーレスポンスを返す
+  if (!supabaseUserId) {
+    console.log("❌ supabaseUserId が提供されていません");
+    return NextResponse.json({ error: "No user ID provided" }, { status: 400 });
+  }
+
+  console.log("✅ supabaseUserId:", supabaseUserId);
+
+  // 該当ユーザーの学習記録を取得（最新順に最大7件）
+  const records = await prisma.learningRecord.findMany({
+    where: {
+      supabaseUserId,
+    },
+    orderBy: {
+      learning_date: "desc", // 新しい順
+    },
+    take: 7,
+    select: {
+      title: true,
+      content: true,
+      duration: true,
+      learning_date: true,
+    },
+  });
+
+  console.log("📚 取得された学習記録:", records);
+
+  // クライアント用に日数やフォーマットを整形
+  const formatted = records.map((record) => ({
+    title: record.title,
+    content: record.content,
+    duration: record.duration,
+    daysAgo: formatDistanceToNow(record.learning_date, {
+      addSuffix: true, // 「～前」の形式で表示（例: "3日前"）
+      locale: ja,
+    }),
+  }));
+
+  console.log("🪄 フォーマット後:", formatted);
+
+  // 整形したデータを JSON として返す
+  return NextResponse.json(formatted);
+}

--- a/src/app/user/dashboard/_components/RecentRecords.tsx
+++ b/src/app/user/dashboard/_components/RecentRecords.tsx
@@ -4,63 +4,67 @@ import { Button } from "@ui/button";
 import {
   Card,
   CardContent,
-  CardDescription,
   CardHeader,
   CardTitle,
+  CardDescription,
 } from "@ui/card";
 import Link from "next/link";
 
-const records = [
-  {
-    days: 1,
-    title: "React Hooks",
-    duration: 2,
-    content: "useEffect と useContext の応用",
-  },
-  {
-    days: 2,
-    title: "Next.js ルーティング",
-    duration: 1.5,
-    content: "動的ルーティングの実装",
-  },
-  {
-    days: 3,
-    title: "TypeScript",
-    duration: 2.5,
-    content: "ジェネリクスとユーティリティ型",
-  },
-];
+// APIから取得した学習記録の型
+interface LearningRecord {
+  id: number;
+  title: string;
+  duration: number;
+  content: string;
+  learning_date: string; // ISO形式の日付文字列
+  daysAgo: string;
+}
 
-const RecentRecords = () => (
-  <Card className="col-span-2">
-    <CardHeader>
-      <CardTitle>最近の学習記録</CardTitle>
-      <CardDescription>直近の学習活動</CardDescription>
-    </CardHeader>
-    <CardContent>
-      <div className="space-y-4">
-        {records.map((record, i) => (
-          <div key={i} className="flex items-center">
-            <div className="w-2 h-2 rounded-full bg-pink-500 mr-2"></div>
-            <div className="flex-1 space-y-1">
-              <p className="text-sm font-medium leading-none">{record.title}</p>
-              <p className="text-sm text-muted-foreground">
-                {record.duration}時間 - {record.content}
-              </p>
-            </div>
-            <div className="text-sm text-muted-foreground">
-              {record.days}日前
-            </div>
-          </div>
-        ))}
-      </div>
-      <Link href="/user/learning-record">
-        <Button variant="outline" className="w-full mt-4">
-          すべての記録を見る
-        </Button>
-      </Link>
-    </CardContent>
-  </Card>
-);
+// コンポーネントProps
+interface RecentRecordsProps {
+  records: LearningRecord[];
+}
+
+const RecentRecords = ({ records }: RecentRecordsProps) => {
+  const today = new Date();
+  console.log("today", today);
+  console.log("records", records);
+
+  return (
+    <Card className="col-span-2">
+      <CardHeader>
+        <CardTitle>最近の学習記録</CardTitle>
+        <CardDescription>直近の学習活動</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          {records.map((record) => {
+            return (
+              <div key={record.id} className="flex items-center">
+                <div className="w-2 h-2 rounded-full bg-pink-500 mr-2" />
+                <div className="flex-1 space-y-1">
+                  <p className="text-sm font-medium leading-none">
+                    {record.title}
+                  </p>
+                  <p className="text-sm text-muted-foreground">
+                    {record.duration.toFixed(1)}時間 - {record.content}
+                  </p>
+                </div>
+                <div className="text-sm text-muted-foreground">
+                  {record.daysAgo}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+        <Link href="/user/learning-record">
+          <Button variant="outline" className="w-full mt-4">
+            すべての記録を見る
+          </Button>
+        </Link>
+      </CardContent>
+    </Card>
+  );
+};
 
 export default RecentRecords;

--- a/src/app/user/dashboard/page.tsx
+++ b/src/app/user/dashboard/page.tsx
@@ -1,54 +1,47 @@
 "use client";
 
-// 必要なHooksやコンポーネントをインポート
+// フロントエンド用のフックと各種コンポーネントをインポート
 import useSWR from "swr";
-import { useSession } from "@utils/session"; // 認証済みユーザー情報の取得
+import { useSession } from "@utils/session";
 import DashboardHeader from "@/app/user/dashboard/_components/DashboardHeader";
 import DashboardStats from "@/app/user/dashboard/_components/DashboardStats";
 import WeeklyCharts from "@/app/user/dashboard/_components/WeeklyCharts";
 import HeatmapSection from "@/app/user/dashboard/_components/HeatmapSection";
 import RecentRecords from "@/app/user/dashboard/_components/RecentRecords";
 import MonthlyGoals from "@/app/user/dashboard/_components/MonthlyGoals";
-import { fetcher } from "@utils/fetcher"; // 共通のデータフェッチ関数
+import { fetcher } from "@utils/fetcher"; // SWRで使用する共通フェッチ関数
 
 export default function Home() {
-  // -------------------------------
-  // 認証済みユーザー情報の取得
-  // -------------------------------
+  // ログイン中のユーザー情報を取得
   const { user } = useSession();
+  const userId = user?.supabaseUserId;
 
-  // -------------------------------
-  // 今週と先週の合計学習時間データを取得
-  // -------------------------------
-  const { data } = useSWR(
-    user?.supabaseUserId
-      ? `/api/user/weekly-learning-duration?supabaseUserId=${user.supabaseUserId}`
+  // =============================
+  // 1. 今週と先週の学習時間を取得
+  // =============================
+  const { data: weeklyDurationData } = useSWR(
+    userId
+      ? `/api/user/weekly-learning-duration?supabaseUserId=${userId}`
       : null,
     fetcher
   );
 
-  // デフォルトは 0 時間
-  const weeklyDuration = data?.weeklyDuration ?? 0;
-  const lastWeekDuration = data?.lastWeekDuration ?? 0;
-
-  // 差分テキスト生成（±表示）
+  const weeklyDuration = weeklyDurationData?.weeklyDuration ?? 0;
+  const lastWeekDuration = weeklyDurationData?.lastWeekDuration ?? 0;
   const diff = weeklyDuration - lastWeekDuration;
   const diffText =
     diff === 0
       ? "先週と同じ"
       : `先週比 ${diff > 0 ? "+" : ""}${diff.toFixed(1)}時間`;
 
-  // -------------------------------
-  // 曜日別の週間学習時間データを取得（棒グラフ用）
-  // -------------------------------
+  // =============================
+  // 2. 曜日別の週間学習時間（棒グラフ）を取得
+  // =============================
   const { data: weeklyChart } = useSWR(
-    user?.supabaseUserId
-      ? `/api/user/weekly-chart-data?supabaseUserId=${user.supabaseUserId}`
-      : null,
+    userId ? `/api/user/weekly-chart-data?supabaseUserId=${userId}` : null,
     fetcher
   );
 
-  // Chart.js 形式に整形（未取得時は初期値）
   const chartData = weeklyChart
     ? {
         labels: weeklyChart.labels,
@@ -71,19 +64,14 @@ export default function Home() {
         ],
       };
 
-  console.log("📊 週間チャートデータ:", chartData);
-
-  // -------------------------------
-  // カテゴリ別学習時間データを取得（円グラフ用）
-  // -------------------------------
+  // =============================
+  // 3. カテゴリ別の学習時間（円グラフ）を取得
+  // =============================
   const { data: categoryRaw } = useSWR(
-    user?.supabaseUserId
-      ? `/api/user/category-distribution?supabaseUserId=${user.supabaseUserId}`
-      : null,
+    userId ? `/api/user/category-distribution?supabaseUserId=${userId}` : null,
     fetcher
   );
 
-  // Chart.js 形式に整形（未取得時は空）
   const categoryData = categoryRaw
     ? {
         labels: categoryRaw.labels,
@@ -105,40 +93,49 @@ export default function Home() {
         datasets: [{ data: [], backgroundColor: [] }],
       };
 
-  console.log("📊 カテゴリ別データ:", categoryData);
-
-  // -------------------------------
-  // ヒートマップ用データを取得（直近90日分）
-  // -------------------------------
+  // =============================
+  // 4. ヒートマップ用データ（直近90日）を取得
+  // =============================
   const { data: heatmapData } = useSWR(
-    user?.supabaseUserId
-      ? `/api/user/heatmap?supabaseUserId=${user.supabaseUserId}`
+    userId ? `/api/user/heatmap?supabaseUserId=${userId}` : null,
+    fetcher
+  );
+
+  // =============================
+  // 5. 最近の学習記録（最新5件）を取得
+  // =============================
+  const { data: recentRecords } = useSWR(
+    userId
+      ? `/api/user/recent-learning-records?supabaseUserId=${userId}`
       : null,
     fetcher
   );
 
-  console.log("🔥 ヒートマップデータ:", heatmapData);
+  // =============================
+  // ログインしていない場合はnullを返す（保護）
+  // =============================
+  if (!userId) return null;
 
-  // -------------------------------
-  // ダッシュボードの描画
-  // -------------------------------
+  // =============================
+  // UI描画
+  // =============================
   return (
     <div className="space-y-6">
       {/* ヘッダー */}
       <DashboardHeader />
 
-      {/* 今週の統計（合計時間・差分） */}
+      {/* 今週の学習統計 */}
       <DashboardStats weeklyDuration={weeklyDuration} diffText={diffText} />
 
-      {/* チャート：棒グラフと円グラフ */}
+      {/* 週間学習時間（棒グラフ）＋ カテゴリ別学習（円グラフ） */}
       <WeeklyCharts chartData={chartData} categoryData={categoryData} />
 
-      {/* ヒートマップ（直近90日） */}
+      {/* ヒートマップ */}
       <HeatmapSection data={heatmapData ?? []} />
 
       {/* 最近の記録 & 今月の目標 */}
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-        <RecentRecords />
+        <RecentRecords records={recentRecords ?? []} />
         <MonthlyGoals />
       </div>
     </div>


### PR DESCRIPTION
## 📝 プルリクエスト: 最近の学習記録の取得機能の実装

### 概要
ダッシュボード上にユーザーの最近の学習記録を表示するための機能を実装しました。

---

### ✅ 対応内容

- `/api/user/recent-learning-records` エンドポイントを作成  
  - ログインユーザーに紐づく学習記録を最新順で最大7件取得  
  - `formatDistanceToNow` を使用して「○日前」と表示  
  - `duration`（学習時間）は小数点1桁に整形

- `RecentRecords` コンポーネントとの連携  
  - propsで取得した記録を一覧表示  
  - UIは既存のカード形式を踏襲

- `Dashboard` 画面でSWRによりデータを取得して渡すように変更  
  - ログインしていない場合は保護（null返却）

---

### 🔍 動作確認

- [x] ログイン状態で `/dashboard` を開いたとき、直近の学習記録が表示される  
- [x] 記録が最大7件まで表示される  
- [x] 日付は「○日前」と日本語で表示される  
- [x] 時間は1桁の小数で表示される（例: `2.5時間`）

---

### 📌 備考

- 今後は各学習記録への詳細ページリンクも検討（別Issue予定）  
- 記録数のカスタマイズ設定なども将来的に追加可能です

---

### 🔚 関連Issueのクローズ

Closes #32
