### PR TITLE
リンク先変更

### DIFF
--- a/src/app/user/dashboard/_components/RecentRecords.tsx
+++ b/src/app/user/dashboard/_components/RecentRecords.tsx
@@ -66,7 +66,7 @@ const RecentRecords = ({ records }: RecentRecordsProps) => {
             );
           })}
         </div>
-        <Link href="/user/learning-record">
+        <Link href="/user/learning-history">
           <Button variant="outline" className="w-full mt-4">
             すべての記録を見る
           </Button>


### PR DESCRIPTION
## 🔀 プルリクエスト概要

「最近の学習記録」コンポーネントに表示されている「すべての記録を見る」のリンク先を、学習記録の一覧ページに適切に遷移するよう修正しました。

---

## 🛠 変更内容

- `RecentRecords.tsx` 内のリンク先を `/user/learning-record` → `/user/learning-history` に変更

---

## 🎯 背景・目的

- `/user/learning-record` はすでに記録作成ページとして利用されているため、誤って作成ページへ遷移してしまう問題があった。
- 今回の修正により、記録の一覧表示専用ページへ正しく遷移できるようになります。

---

## ✅ 関連Issue

- #40

---
