### PR TITLE
Feature/issue42 add home guide

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,23 @@
 {
+  // ファイル監視対象から除外してVSCodeを軽くする
+  "files.watcherExclude": {
+    "**/node_modules/**": true,
+    "**/.git/**": true,
+    "**/.next/**": true,
+    "**/dist/**": true,
+    "**/out/**": true,
+    "**/.turbo/**": true
+  },
+
+  // ファイル検索対象からも除外する
+  "search.exclude": {
+    "**/node_modules": true,
+    "**/.next": true,
+    "**/dist": true,
+    "**/out": true,
+    "**/.turbo": true
+  },
+
+  // スペルチェック (cSpell) で "lernova" を単語リストに追加
   "cSpell.words": ["lernova"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@hookform/resolvers": "^4.1.3",
         "@mui/material": "^6.4.8",
         "@prisma/client": "^6.6.0",
+        "@radix-ui/react-accordion": "^1.2.8",
         "@radix-ui/react-avatar": "^1.1.3",
         "@radix-ui/react-checkbox": "^1.1.4",
         "@radix-ui/react-collapsible": "^1.1.3",
@@ -2126,6 +2127,37 @@
       "integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==",
       "license": "MIT"
     },
+    "node_modules/@radix-ui/react-accordion": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.8.tgz",
+      "integrity": "sha512-c7OKBvO36PfQIUGIjj1Wko0hH937pYFU2tR5zbIJDUsmTzHoZVHHt4bmb7OOJbzTaWJtVELKWojBHa7OcnUHmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-collapsible": "1.1.8",
+        "@radix-ui/react-collection": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.0",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.4.tgz",
@@ -2207,18 +2239,42 @@
       }
     },
     "node_modules/@radix-ui/react-collapsible": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.7.tgz",
-      "integrity": "sha512-zGFsPcFJNdQa/UNd6MOgF40BS054FIGj32oOWBllixz42f+AkQg3QJ1YT9pw7vs+Ai+EgWkh839h69GEK8oH2A==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.8.tgz",
+      "integrity": "sha512-hxEsLvK9WxIAPyxdDRULL4hcaSjMZCfP7fHB0Z1uUnDoDBat1Zh46hwYfa69DeZAbJrPckjf0AGAtEZyvDyJbw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.2",
         "@radix-ui/react-compose-refs": "1.1.2",
         "@radix-ui/react-context": "1.1.2",
         "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-presence": "1.1.3",
+        "@radix-ui/react-presence": "1.1.4",
         "@radix-ui/react-primitive": "2.1.0",
         "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.4.tgz",
+      "integrity": "sha512-ueDqRbdc4/bkaQT3GIpLQssRlFgWaL/U2z/S31qRwwLWoxHLgry3SIfCwhxeQNbirEUXFa+lq3RL3oBYXtcmIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
         "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@hookform/resolvers": "^4.1.3",
     "@mui/material": "^6.4.8",
     "@prisma/client": "^6.6.0",
+    "@radix-ui/react-accordion": "^1.2.8",
     "@radix-ui/react-avatar": "^1.1.3",
     "@radix-ui/react-checkbox": "^1.1.4",
     "@radix-ui/react-collapsible": "^1.1.3",

--- a/src/app/_components/ui/accordion.tsx
+++ b/src/app/_components/ui/accordion.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import * as React from "react"
+import * as AccordionPrimitive from "@radix-ui/react-accordion"
+import { ChevronDown } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Accordion = AccordionPrimitive.Root
+
+const AccordionItem = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <AccordionPrimitive.Item
+    ref={ref}
+    className={cn("border-b", className)}
+    {...props}
+  />
+))
+AccordionItem.displayName = "AccordionItem"
+
+const AccordionTrigger = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <AccordionPrimitive.Header className="flex">
+    <AccordionPrimitive.Trigger
+      ref={ref}
+      className={cn(
+        "flex flex-1 items-center justify-between py-4 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronDown className="h-4 w-4 shrink-0 transition-transform duration-200" />
+    </AccordionPrimitive.Trigger>
+  </AccordionPrimitive.Header>
+))
+AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName
+
+const AccordionContent = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <AccordionPrimitive.Content
+    ref={ref}
+    className="overflow-hidden text-sm transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+    {...props}
+  >
+    <div className={cn("pb-4 pt-0", className)}>{children}</div>
+  </AccordionPrimitive.Content>
+))
+
+AccordionContent.displayName = AccordionPrimitive.Content.displayName
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent }

--- a/src/app/_components/ui/badge.tsx
+++ b/src/app/_components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -84,7 +84,7 @@ export default function LoginPage() {
 
     // ログイン成功時、ホームページにリダイレクト
     if (user) {
-      router.push("/"); // ログイン成功後、ホームページにリダイレクト
+      router.push("/user/dashboard"); // ログイン成功後、ホームページにリダイレクト
     }
   };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,33 +1,204 @@
 "use client";
 
-import { useLogout } from "@hooks/useLogout"; // useLogoutをインポート
+import Link from "next/link";
 import { useSession } from "@utils/session";
+import { Button } from "./_components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "./_components/ui/card";
+import {
+  BarChart2,
+  BookOpen,
+  Clock,
+  HelpCircle,
+  Home,
+  PlusCircle,
+} from "lucide-react";
 
-export default function Home() {
+const FeatureBadge = () => (
+  <span className="ml-2 text-xs bg-yellow-100 text-yellow-800 border border-yellow-300 rounded px-2 py-0.5">
+    開発中
+  </span>
+);
+
+const lernovaFeatures = [
+  {
+    title: "学習記録",
+    desc: "日々の学習内容と時間を記録し、カテゴリ別に管理できます。",
+  },
+  {
+    title: "進捗可視化",
+    desc: "ヒートマップやグラフで学習時間の推移を確認できます。",
+  },
+  {
+    title: "月別分析",
+    desc: "月ごとの学習時間やカテゴリ別の学習バランスを分析できます。",
+  },
+];
+
+const mainFunctions = [
+  {
+    icon: <Home className="mt-1 h-5 w-5 text-pink-500" />,
+    title: "ダッシュボード",
+    desc: "学習時間の概要、週間学習時間、カテゴリ別学習時間、学習進捗カレンダーなどを一目で確認できます。",
+  },
+  {
+    icon: <PlusCircle className="mt-1 h-5 w-5 text-pink-500" />,
+    title: "学習記録",
+    desc: "学習内容、カテゴリ、時間を記録できます。タイマー機能も使用可能です。",
+  },
+  {
+    icon: <Clock className="mt-1 h-5 w-5 text-pink-500" />,
+    title: "学習履歴",
+    desc: (
+      <>
+        過去の学習記録を一覧で確認できます。月ごとの表示や検索、フィルタリング機能も利用可能です。
+        <FeatureBadge />
+      </>
+    ),
+  },
+  {
+    icon: <BarChart2 className="mt-1 h-5 w-5 text-pink-500" />,
+    title: "進捗管理",
+    desc: (
+      <>
+        学習目標の設定と進捗トラッキング、カテゴリ別の学習時間分析などが可能になる予定です。
+        <FeatureBadge />
+      </>
+    ),
+  },
+];
+
+export default function GuidePage() {
   const { user, isError } = useSession();
-  const { handleLogout } = useLogout(); // useLogoutを呼び出す
 
   if (isError) {
     return <div>ユーザー情報の取得に失敗しました。</div>;
   }
 
   return (
-    <div className="min-h-screen flex justify-center items-center">
-      <div>
+    <div className="min-h-screen p-8 space-y-6">
+      {/* ユーザー情報 */}
+      <div className="flex justify-between items-center">
         {user ? (
-          <>
-            <p>こんにちは, {user.nickname ?? user.email} さん！</p>
-            {/* ログアウトボタン */}
-            <button
-              onClick={handleLogout}
-              className="mt-4 px-4 py-2 bg-red-600 text-white rounded"
-            >
-              ログアウト
-            </button>
-          </>
+          <p className="text-sm text-muted-foreground">
+            <span className="font-semibold">{user.nickname ?? user.email}</span>{" "}
+            さん、ようこそLernovaへ！
+          </p>
         ) : (
-          <p>ログインしていません。</p>
+          <p className="text-sm text-muted-foreground">
+            ログインしていません。
+          </p>
         )}
+      </div>
+
+      {/* タイトル */}
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight">Lernovaの使い方</h1>
+        <p className="text-muted-foreground">
+          Lernovaは学習を継続的にサポートし、ユーザーが自分の進捗を可視化できるアプリです。
+          このガイドでは、主要機能と基本的な使い方について紹介します。
+        </p>
+      </div>
+
+      {/* Lernovaとは */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Lernovaとは</CardTitle>
+          <CardDescription>
+            学習継続をサポートするアプリケーション
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-4 md:grid-cols-3">
+          {lernovaFeatures.map(({ title, desc }, idx) => (
+            <Card key={idx}>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-lg">{title}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm">{desc}</p>
+              </CardContent>
+            </Card>
+          ))}
+        </CardContent>
+      </Card>
+
+      {/* 主な機能 */}
+      <Card>
+        <CardHeader>
+          <CardTitle>主な機能</CardTitle>
+          <CardDescription>Lernovaで利用できる主な機能</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {mainFunctions.map(({ icon, title, desc }, idx) => (
+            <div key={idx} className="flex items-start gap-4">
+              {icon}
+              <div>
+                <h3 className="font-medium">{title}</h3>
+                <p className="text-sm text-muted-foreground">{desc}</p>
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      {/* 基本的な使い方 */}
+      <Card>
+        <CardHeader>
+          <CardTitle>はじめに</CardTitle>
+          <CardDescription>Lernovaを始めるための基本ステップ</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="rounded-md bg-muted p-4 space-y-2">
+            <div className="flex items-center gap-2">
+              <HelpCircle className="h-5 w-5 text-pink-500" />
+              <h3 className="font-medium">基本的な使い方</h3>
+            </div>
+            <ol className="text-sm list-decimal pl-6 space-y-2">
+              <li>
+                <strong>ダッシュボードを確認する</strong>
+                ：ログイン後、学習状況をひと目で把握しましょう。
+              </li>
+              <li>
+                <strong>学習を記録する</strong>
+                ：学習内容や時間をすぐに記録しましょう。
+              </li>
+              <li>
+                <strong>学習履歴を振り返る</strong>
+                ：過去の記録から自分の成長をチェックしましょう。
+              </li>
+              <li>
+                <strong>進捗を分析する</strong>
+                ：カレンダーやグラフでパターンを見つけて活かしましょう。
+              </li>
+            </ol>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* はじめての方へ案内 */}
+      <div className="rounded-md bg-muted p-4">
+        <div className="flex items-center gap-2">
+          <BookOpen className="h-5 w-5 text-pink-500" />
+          <h3 className="font-medium">Lernovaをはじめてみませんか？</h3>
+        </div>
+        <p className="mt-2 text-sm">
+          Lernovaは、学びを記録し、成長を可視化するアプリです。
+          継続をサポートする豊富な機能を体験するには、ログインまたは新規登録が必要です。
+          あなたの学びの旅を、今日からスタートしましょう！
+        </p>
+        <div className="mt-4 flex gap-2">
+          <Link href="/signup">
+            <Button className="bg-pink-500 hover:bg-pink-600">新規登録</Button>
+          </Link>
+          <Link href="/login">
+            <Button variant="outline">ログイン</Button>
+          </Link>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## 概要

ホーム画面に「Lernovaの使い方」を紹介する**アプリガイドセクション**を追加しました。
新規ユーザーや既存ユーザーがアプリの利用方法を直感的に理解できるようにするための改善です。

---

## 変更内容

- `GuidePage` コンポーネントを作成
  - Lernovaとは
  - 主な機能
  - 基本的な使い方
  - はじめての方への新規登録・ログイン案内
- ユーザー情報（ニックネーム or メールアドレス）を表示
- ログインしていない場合は、ログインや新規登録を促す案内を表示
- アイコン（Home, PlusCircle, Clock, BarChart2, etc）を活用して視覚的に理解しやすいレイアウトを設計
- ボタンコンポーネント、カードコンポーネントを用いてデザイン統一

---

## 実装ポイント

- `useSession` を使用し、ログイン状態を判定
- `lucide-react` アイコンで各機能を視覚的に表現
- ログインしていないユーザーには、新規登録/ログインへの動線を自然に設置
- TailwindCSSを用いたシンプルかつ柔らかいデザインに統一
- コンポーネントの再利用性を意識して、コードを整理

---

## 確認してほしい点

- レイアウト崩れがないか
- 各リンクボタン（サポートページ、新規登録、ログイン）が正しく動作するか
- ログイン/未ログイン状態に応じた表示切り替えが問題ないか

---

## 関連Issue

- close #42  


---


## スクリーンショット

![screencapture-localhost-3000-2025-04-26-06_52_58](https://github.com/user-attachments/assets/4de9483a-ca1f-4d97-bc01-1ed1524c1de3)

---

