### PR TITLE
#44  学習記録削除時に本当のベスト連続記録を再計算する機能の追加

### DIFF
--- a/src/app/_utils/learningStreak.ts
+++ b/src/app/_utils/learningStreak.ts
@@ -3,13 +3,35 @@ import { format, subDays } from "date-fns";
 
 const prisma = new PrismaClient();
 
-// 日付のセットから連続日数を計算
-export function calculateStreak(dates: Set<string>, today = new Date()) {
+const DAYS_RANGE = 90;
+
+/**
+ * 📚 日付を "yyyy-MM-dd" 文字列に変換
+ */
+function formatDate(date: Date): string {
+  return format(date, "yyyy-MM-dd");
+}
+
+/**
+ * 📚 日付の差分（日数）を計算
+ */
+function getDateDiffInDays(date1: Date, date2: Date): number {
+  const diffMs = date1.getTime() - date2.getTime();
+  return Math.floor(diffMs / (1000 * 60 * 60 * 24));
+}
+
+/**
+ * 📚 与えられた日付セットから「直近の連続学習日数」を計算する
+ */
+export function calculateStreak(
+  dates: Set<string>,
+  today = new Date()
+): number {
   let streak = 0;
   const current = new Date(today);
 
-  for (let i = 0; i < 90; i++) {
-    const dateStr = format(current, "yyyy-MM-dd");
+  for (let i = 0; i < DAYS_RANGE; i++) {
+    const dateStr = formatDate(current);
     if (dates.has(dateStr)) {
       streak++;
       current.setDate(current.getDate() - 1);
@@ -20,40 +42,55 @@ export function calculateStreak(dates: Set<string>, today = new Date()) {
   return streak;
 }
 
-// supabaseUserIdから学習記録を取得
-export async function getLearningDates(supabaseUserId: string) {
+/**
+ * 📚 指定したユーザーの過去90日間の学習記録日付セットを取得
+ */
+export async function getLearningDates(
+  supabaseUserId: string
+): Promise<Set<string>> {
   const today = new Date();
-  const startDate = subDays(today, 89);
+  const startDate = subDays(today, DAYS_RANGE - 1);
 
   const records = await prisma.learningRecord.findMany({
     where: {
       supabaseUserId,
-      learning_date: {
-        gte: startDate,
-        lte: today,
-      },
+      learning_date: { gte: startDate, lte: today },
     },
     select: { learning_date: true },
   });
 
-  return new Set(records.map((r) => format(r.learning_date, "yyyy-MM-dd")));
+  return new Set(records.map((r) => formatDate(r.learning_date)));
 }
 
-// ベスト streak の保存 or 更新
+/**
+ * 📚 ユーザーの全学習記録日付セットを取得（全期間対象）
+ */
+export async function getAllLearningDates(
+  supabaseUserId: string
+): Promise<Set<string>> {
+  const records = await prisma.learningRecord.findMany({
+    where: { supabaseUserId },
+    select: { learning_date: true },
+    orderBy: { learning_date: "desc" },
+  });
+
+  return new Set(records.map((r) => formatDate(r.learning_date)));
+}
+
+/**
+ * 📚 ベスト連続記録（streak）を保存・更新
+ */
 export async function saveOrUpdateBestStreak(
   supabaseUserId: string,
   currentStreak: number
-) {
+): Promise<number> {
   const existing = await prisma.streak.findUnique({
     where: { supabaseUserId },
   });
 
   if (!existing) {
     await prisma.streak.create({
-      data: {
-        supabaseUserId,
-        best_streak: currentStreak,
-      },
+      data: { supabaseUserId, best_streak: currentStreak },
     });
     return currentStreak;
   }
@@ -67,4 +104,62 @@ export async function saveOrUpdateBestStreak(
   }
 
   return existing.best_streak;
+}
+
+/**
+ * 📚 ✅ 学習記録の追加・更新・削除後に「直近の継続日数」を再計算してベストも更新
+ */
+export async function recalculateStreakAfterLearningChange(
+  supabaseUserId: string
+): Promise<{ currentStreak: number; bestStreak: number }> {
+  const dates = await getLearningDates(supabaseUserId);
+  const currentStreak = calculateStreak(dates);
+  const bestStreak = await saveOrUpdateBestStreak(
+    supabaseUserId,
+    currentStreak
+  );
+
+  console.log("📈 継続日数を再計算:", { currentStreak, bestStreak });
+  return { currentStreak, bestStreak };
+}
+
+/**
+ * 📚 ✅ 全学習履歴から「本当のベスト連続記録」を再計算して保存
+ */
+export async function recalculateBestStreak(
+  supabaseUserId: string
+): Promise<number> {
+  const datesSet = await getAllLearningDates(supabaseUserId);
+  const sortedDates = Array.from(datesSet).sort((a, b) => (a > b ? -1 : 1));
+
+  let best = 0;
+  let streak = 0;
+  let prevDate: Date | null = null;
+
+  for (const dateStr of sortedDates) {
+    const currentDate = new Date(dateStr);
+
+    if (prevDate) {
+      const diffDays = getDateDiffInDays(prevDate, currentDate);
+      if (diffDays === 1) {
+        streak++;
+      } else {
+        streak = 1;
+      }
+    } else {
+      streak = 1;
+    }
+
+    best = Math.max(best, streak);
+    prevDate = currentDate;
+  }
+
+  await prisma.streak.upsert({
+    where: { supabaseUserId },
+    create: { supabaseUserId, best_streak: best },
+    update: { best_streak: best },
+  });
+
+  console.log("🏆 本当のベスト連続日数を再計算・更新:", best);
+  return best;
 }

--- a/src/app/_utils/learningStreak.ts
+++ b/src/app/_utils/learningStreak.ts
@@ -1,0 +1,70 @@
+import { PrismaClient } from "@prisma/client";
+import { format, subDays } from "date-fns";
+
+const prisma = new PrismaClient();
+
+// 日付のセットから連続日数を計算
+export function calculateStreak(dates: Set<string>, today = new Date()) {
+  let streak = 0;
+  const current = new Date(today);
+
+  for (let i = 0; i < 90; i++) {
+    const dateStr = format(current, "yyyy-MM-dd");
+    if (dates.has(dateStr)) {
+      streak++;
+      current.setDate(current.getDate() - 1);
+    } else {
+      break;
+    }
+  }
+  return streak;
+}
+
+// supabaseUserIdから学習記録を取得
+export async function getLearningDates(supabaseUserId: string) {
+  const today = new Date();
+  const startDate = subDays(today, 89);
+
+  const records = await prisma.learningRecord.findMany({
+    where: {
+      supabaseUserId,
+      learning_date: {
+        gte: startDate,
+        lte: today,
+      },
+    },
+    select: { learning_date: true },
+  });
+
+  return new Set(records.map((r) => format(r.learning_date, "yyyy-MM-dd")));
+}
+
+// ベスト streak の保存 or 更新
+export async function saveOrUpdateBestStreak(
+  supabaseUserId: string,
+  currentStreak: number
+) {
+  const existing = await prisma.streak.findUnique({
+    where: { supabaseUserId },
+  });
+
+  if (!existing) {
+    await prisma.streak.create({
+      data: {
+        supabaseUserId,
+        best_streak: currentStreak,
+      },
+    });
+    return currentStreak;
+  }
+
+  if (currentStreak > existing.best_streak) {
+    await prisma.streak.update({
+      where: { supabaseUserId },
+      data: { best_streak: currentStreak },
+    });
+    return currentStreak;
+  }
+
+  return existing.best_streak;
+}

--- a/src/app/api/user/learning-streak/route.ts
+++ b/src/app/api/user/learning-streak/route.ts
@@ -1,94 +1,20 @@
 import { NextRequest, NextResponse } from "next/server";
-import { PrismaClient } from "@prisma/client";
-import { format, subDays } from "date-fns";
-
-const prisma = new PrismaClient();
-
-// 🔧 連続日数の計算ロジックを関数化
-function getStreakFromRecords(dates: Set<string>) {
-  let streak = 0;
-  const current = new Date();
-
-  for (let i = 0; i < 90; i++) {
-    const dateStr = format(current, "yyyy-MM-dd");
-
-    if (dates.has(dateStr)) {
-      streak++;
-      console.log(`✅ ${dateStr} は記録あり（連続 ${streak} 日目）`);
-      current.setDate(current.getDate() - 1);
-    } else {
-      console.log(`⛔️ ${dateStr} に記録なし → streak終了`);
-      break;
-    }
-  }
-
-  return streak;
-}
+import {
+  calculateStreak,
+  getLearningDates,
+  saveOrUpdateBestStreak,
+} from "@utils/learningStreak";
 
 export async function GET(req: NextRequest) {
   const supabaseUserId = req.nextUrl.searchParams.get("supabaseUserId");
 
-  console.log("🚀 /api/user/learning-streak にリクエストが来ました");
-
-  // Prisma Client に存在するモデルを表示（streak があるか確認）
-  const models = Object.keys(prisma);
-  console.log("🧩 Prisma モデル一覧:", models);
-
   if (!supabaseUserId) {
-    console.warn("❌ supabaseUserId がありません");
     return NextResponse.json({ error: "No user ID provided" }, { status: 400 });
   }
 
-  // 🔎 対象期間の記録を取得（過去90日）
-  const today = new Date();
-  const startDate = subDays(today, 89);
+  const dates = await getLearningDates(supabaseUserId);
+  const streak = calculateStreak(dates);
+  const bestStreak = await saveOrUpdateBestStreak(supabaseUserId, streak);
 
-  const records = await prisma.learningRecord.findMany({
-    where: {
-      supabaseUserId,
-      learning_date: {
-        gte: startDate,
-        lte: today,
-      },
-    },
-    select: {
-      learning_date: true,
-    },
-  });
-
-  const dateSet = new Set(
-    records.map((r) => format(r.learning_date, "yyyy-MM-dd"))
-  );
-
-  const streak = getStreakFromRecords(dateSet);
-  console.log("📈 現在の連続日数:", streak);
-
-  // 📌 現在のベスト記録を確認
-  const existing = await prisma.streak.findUnique({
-    where: { supabaseUserId },
-  });
-
-  // 🔄 ベスト記録の保存 or 更新
-  if (!existing) {
-    await prisma.streak.create({
-      data: {
-        supabaseUserId,
-        best_streak: streak,
-      },
-    });
-    console.log("🆕 Streak レコードを新規作成");
-  } else if (streak > existing.best_streak) {
-    await prisma.streak.update({
-      where: { supabaseUserId },
-      data: { best_streak: streak },
-    });
-    console.log("🏆 ベスト streak を更新:", streak);
-  } else {
-    console.log("🟡 ベスト streak に変更なし");
-  }
-
-  return NextResponse.json({
-    streak,
-    bestStreak: Math.max(streak, existing?.best_streak ?? 0),
-  });
+  return NextResponse.json({ streak, bestStreak });
 }

--- a/src/app/user/learning-record/page.tsx
+++ b/src/app/user/learning-record/page.tsx
@@ -78,7 +78,6 @@ export default function TimeInputPage() {
   }, [title, category, newCategory]);
 
   // タイマー停止＋サーバー保存
-  // タイマー停止＋サーバー保存
   const handleStop = useCallback(async () => {
     const st = localStorage.getItem("learning_start_time");
     if (!st)
@@ -166,7 +165,7 @@ export default function TimeInputPage() {
 
   // 全件画面へ
   const onViewAll = useCallback(() => {
-    router.push("/user/learning-record");
+    router.push("/user/learning-history");
   }, [router]);
 
   return (


### PR DESCRIPTION
# 🛠️ 学習記録削除時に本当のベスト連続記録を再計算する機能の追加

## 概要
学習記録を**削除（DELETE）**した後に、  
**正しいベスト連続日数（best_streak）**を再計算・更新する仕組みを追加しました。

これにより、記録の削除によって連続記録の整合性が崩れる問題を防ぎます。

---

## 実装内容

- `src/app/_utils/learningStreak.ts`
  - `recalculateBestStreak` 関数を作成
    - **全学習履歴**を取得し、連続日数を再計算して保存
- **DELETE** `/api/user/learning-record/[learningRecordId]` エンドポイント
  - 削除後に `recalculateBestStreak` を呼び出し、ベスト記録を正しく更新
- 削除操作完了後に、最新の `bestStreak` をレスポンスに含めるよう修正

---

## 目的

- 学習記録を削除した場合でも、**ベスト連続記録**の整合性を維持するため
- 将来的な継続日数バッジやユーザーステータス表示の正確性を確保するため

---

## 注意点

- 削除時は**直近90日間**ではなく、**全履歴**を対象にベストを再計算します
- 追加・修正時の再計算（直近90日分）はこれまで通り `recalculateStreakAfterLearningChange` を使用します

---

## 関連Issue

- Close #44 