### PR TITLE
継続日数(streak)計算ロジックの改善

### DIFF
--- a/src/app/_utils/learningStreak.ts
+++ b/src/app/_utils/learningStreak.ts
@@ -22,23 +22,39 @@ function getDateDiffInDays(date1: Date, date2: Date): number {
 
 /**
  * 📚 与えられた日付セットから「直近の連続学習日数」を計算する
+ *
+ * @param dates - "yyyy-MM-dd" 形式の日付文字列の集合（Set）
+ * @param today - 計算の基準日（省略時は現在の日付）
+ * @returns 直近の連続学習日数（streak）
  */
-export function calculateStreak(
-  dates: Set<string>,
-  today = new Date()
-): number {
+export function calculateStreak(dates: Set<string>, today = new Date()) {
   let streak = 0;
-  const current = new Date(today);
+  let current: Date;
 
-  for (let i = 0; i < DAYS_RANGE; i++) {
-    const dateStr = formatDate(current);
+  const todayStr = format(today, "yyyy-MM-dd");
+  const yesterdayStr = format(subDays(today, 1), "yyyy-MM-dd");
+
+  // ✅ 今日に記録がある場合は今日から、なければ昨日から数え始める
+  if (dates.has(todayStr)) {
+    current = new Date(today);
+  } else if (dates.has(yesterdayStr)) {
+    current = subDays(today, 1);
+  } else {
+    // 今日も昨日も記録がない場合は streak=0
+    return 0;
+  }
+
+  // 📆 最大90日前まで遡って、連続した日数をカウントする
+  for (let i = 0; i < 90; i++) {
+    const dateStr = format(current, "yyyy-MM-dd");
     if (dates.has(dateStr)) {
-      streak++;
-      current.setDate(current.getDate() - 1);
+      streak++; // 記録があればカウントを増やす
+      current.setDate(current.getDate() - 1); // 1日戻る
     } else {
-      break;
+      break; // 連続していなければ終了
     }
   }
+
   return streak;
 }
 


### PR DESCRIPTION
# fix: 継続日数が0になる問題を修正 (#48)

## 概要
ダッシュボードなどで表示している「継続日数（streak）」について、  
日付が変わった直後にまだ学習していない場合でも0日と表示されてしまう問題がありました。

このプルリクでは、**今日または昨日に記録がある場合は継続扱い**として  
より自然な継続日数が表示されるように `calculateStreak` 関数を修正しました。

---

## 修正内容
- `calculateStreak` を改良
  - 今日または昨日に記録があればそこからstreakをカウント
  - 今日も昨日も記録がなければ0とする
- 不要なデバッグログ（`console.log`）を削除
- 関数全体にコメントを付与し、可読性と保守性を向上

---

## 修正前の問題点
- 日付が変わった直後に0日表示になり、継続中にもかかわらず「途切れたように見える」

## 修正後の改善点
- 今日まだ記録していなくても、昨日まで継続していればstreakが継続して見える
- ユーザー体験(UX)の向上

---

## 関連Issue
Closes #48
