### PR TITLE
learningStreak.tsで型エラー修正

### DIFF
--- a/src/app/_utils/learningStreak.ts
+++ b/src/app/_utils/learningStreak.ts
@@ -75,7 +75,9 @@ export async function getLearningDates(
     select: { learning_date: true },
   });
 
-  return new Set(records.map((r) => formatDate(r.learning_date)));
+  return new Set(
+    records.map((r: { learning_date: Date }) => formatDate(r.learning_date))
+  );
 }
 
 /**
@@ -90,7 +92,9 @@ export async function getAllLearningDates(
     orderBy: { learning_date: "desc" },
   });
 
-  return new Set(records.map((r) => formatDate(r.learning_date)));
+  return new Set(
+    records.map((r: { learning_date: Date }) => formatDate(r.learning_date))
+  );
 }
 
 /**


### PR DESCRIPTION
## 概要

`learningStreak.ts` において、`learning_date` の型が `string` と誤認識されていたため、ビルドエラーが発生していました。  
本プルリクでは、正しい `Date` 型に修正しました。

## 修正内容

- `learningStreak.ts` 内で `records.map((r)` の `r` の型を `{ learning_date: Date }` に正しく型注釈
- `learning_date` は `Date` 型前提で `formatDate` 関数に渡すように修正

## 対応理由

Vercelデプロイ時に以下のエラーが発生していたため。

> Type error: 型 '(r: { learning_date: string; }) => string' の引数を型 '(value: { learning_date: Date; }, index: number, array: { learning_date: Date; }[]) => string' のパラメーターに割り当てることはできません。

これは `learning_date` の型を `string` と誤解していたことが原因です。

## 関連Issue

- Close #55

## その他

- ローカルで `npm run build` 成功確認済み ✅
- Vercelプレビュー環境でのビルド通過も確認予定
