### PR TITLE
/api/user/category-distribution 型エラー修正

### DIFF
--- a/src/app/api/user/category-distribution/route.ts
+++ b/src/app/api/user/category-distribution/route.ts
@@ -3,6 +3,13 @@ import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();
 
+type GroupedRecord = {
+  categoryId: number;
+  _sum: {
+    duration: number | null;
+  };
+};
+
 export async function GET(req: NextRequest) {
   const supabaseUserId = req.nextUrl.searchParams.get("supabaseUserId");
 
@@ -23,7 +30,7 @@ export async function GET(req: NextRequest) {
   const labels: string[] = [];
   const data: number[] = [];
 
-  records.forEach((record) => {
+  records.forEach((record: GroupedRecord) => {
     const category = categories.find((c) => c.id === record.categoryId);
     if (category) {
       labels.push(category.category_name);


### PR DESCRIPTION
# 概要
Prismaの `groupBy` を使ったデータ取得時に、`_sum` プロパティが型定義されておらず、ビルドエラーが発生していました。
これを正しい型で扱うように修正しました。

# 変更内容
- `records` の型を `{ categoryId: number; _sum: { duration: number | null } }` に修正
- `record._sum.duration` を安全に参照できるように変更
- Prismaの型チェックエラーを解消

# 修正前の問題
- `record._sum` が存在しない型として扱われていた
- デプロイ時にビルドエラーが発生していた

# 修正後の効果
- 型エラーが解消され、正常にビルド・デプロイ可能に
- 集計データが正しく取得できる

# 関連Issue
Close #57
