### PR TITLE
学習記録編集後にヒートマップへ即時反映する

### DIFF
--- a/src/app/_utils/timeUtils.ts
+++ b/src/app/_utils/timeUtils.ts
@@ -25,8 +25,8 @@ export const convertToJST = (utcDate: string): string => {
 
 // 日本時間から時間部分 (HH:mm) を抽出する関数
 export const extractTime = (utcDate: string): string => {
-  console.log("extractTime関数が呼び出されました"); // デバッグ用
-  console.log("utcDate:", utcDate); // デバッグ用
+  // console.log("extractTime関数が呼び出されました"); // デバッグ用
+  // console.log("utcDate:", utcDate); // デバッグ用
   const zonedTime = convertToJSTDate(utcDate); // UTCを日本時間に変換
   return format(zonedTime, "HH:mm"); // 時間部分のみ取得
 };

--- a/src/app/user/learning-history/_components/LearningRecordTable.tsx
+++ b/src/app/user/learning-history/_components/LearningRecordTable.tsx
@@ -68,7 +68,7 @@ const LearningRecordTable: React.FC<LearningRecordTableProps> = ({
 
         <TableBody>
           {sortedRecords.map((record: LearningRecord) => {
-            console.log("一覧表示map後record:", record); // デバッグ用
+            // console.log("一覧表示map後record:", record); // デバッグ用
             return (
               <TableRow key={record.id}>
                 <TableCell className="font-medium">{record.title}</TableCell>

--- a/src/app/user/learning-history/page.tsx
+++ b/src/app/user/learning-history/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, useCallback } from "react";
 import useSWR from "swr";
+import { mutate } from "swr";
 import LearningRecordDialog from "./_components/LearningRecordDialog";
 import LearningRecordTable from "./_components/LearningRecordTable";
 import HeatmapSection from "@/app/user/dashboard/_components/HeatmapSection";
@@ -20,6 +21,14 @@ const LearningHistory = () => {
     userId ? `/api/user/heatmap?supabaseUserId=${userId}` : null,
     fetcher
   );
+
+  // ヒートマップ更新関数を作成
+  const refreshHeatmap = () => {
+    if (user?.supabaseUserId) {
+      console.log("ヒートマップのデータを更新");
+      mutate(`/api/user/heatmap?supabaseUserId=${user.supabaseUserId}`);
+    }
+  };
 
   // 学習記録を変換する関数
   const transformRecord = (rawRecord: RawRecord): LearningRecord => ({
@@ -72,6 +81,7 @@ const LearningHistory = () => {
       if (!response.ok) throw new Error("学習記録の保存に失敗しました");
 
       await fetchLearningRecords();
+      refreshHeatmap();
     } catch (error) {
       console.error(error);
       alert("学習記録の保存に失敗しました");
@@ -94,6 +104,7 @@ const LearningHistory = () => {
       if (!response.ok) throw new Error("学習記録の削除に失敗しました");
 
       setRecords(records.filter((record) => record.id !== id));
+      refreshHeatmap();
     } catch (error) {
       console.error(error);
       alert("削除に失敗しました");
@@ -127,6 +138,7 @@ const LearningHistory = () => {
         )
       );
       setRecordToEdit(null);
+      refreshHeatmap();
     } catch (error) {
       console.error(error);
       alert("学習記録の保存に失敗しました");


### PR DESCRIPTION
## 概要

学習記録編集後、削除後、新規登録後にヒートマップを自動更新するように修正しました。

これにより、編集や追加、削除した学習記録がリアルタイムでダッシュボードのヒートマップに反映されるようになります。

## 変更内容

- `refreshHeatmap` 関数を作成し、ヒートマップデータの再取得処理を共通化
- 学習記録の **新規追加成功時** に `refreshHeatmap` を呼び出す
- 学習記録の **編集保存成功時** に `refreshHeatmap` を呼び出す
- 学習記録の **削除成功時** に `refreshHeatmap` を呼び出す

## 修正理由

これまで学習記録を更新しても、ヒートマップに反映されず、画面をリロードしないと更新が確認できなかったため。

## 特記事項

- `mutate` を使ってキャッシュの再取得を行っています
- ユーザーが存在しない場合は `refreshHeatmap` を実行しないようガードしています
- **fetchLearningRecords()** と併せて呼び出す箇所もありますが、ヒートマップ専用に関数を分けています

## CloseするIssue

- Close #70
