### PR TITLE
【改善】保存処理中の状態管理と保存中表示を追加

### DIFF
--- a/src/app/user/learning-history/_components/LearningRecordDialog.tsx
+++ b/src/app/user/learning-history/_components/LearningRecordDialog.tsx
@@ -25,6 +25,7 @@ interface LearningRecordDialogProps {
   recordToEdit: LearningRecord | null;
   isEditing: boolean;
   setRecordToEdit: (record: LearningRecord | null) => void; // 親からsetRecordToEditを受け取る
+  isSaving: boolean;
 }
 
 const LearningRecordDialog = ({
@@ -33,6 +34,7 @@ const LearningRecordDialog = ({
   recordToEdit,
   isEditing,
   setRecordToEdit, // setRecordToEditを受け取る
+  isSaving,
 }: LearningRecordDialogProps) => {
   const [title, setTitle] = useState("");
   const [date, setDate] = useState(""); // 開始日付
@@ -245,9 +247,17 @@ const LearningRecordDialog = ({
             type="button"
             onClick={handleSubmit}
             className="bg-pink-500 hover:bg-pink-600"
+            disabled={isSaving} // 保存中は押せないようにする
           >
-            {isEditing ? "保存" : "追加"}
+            {isSaving
+              ? isEditing
+                ? "更新中..."
+                : "保存中..." // 保存中の文言を切り替え
+              : isEditing
+              ? "更新"
+              : "追加"}{" "}
           </Button>
+
           <Button
             type="button"
             onClick={handleDialogClose} // ダイアログを閉じる

--- a/src/app/user/learning-history/page.tsx
+++ b/src/app/user/learning-history/page.tsx
@@ -13,6 +13,7 @@ import { fetcher } from "@utils/fetcher";
 const LearningHistory = () => {
   const [records, setRecords] = useState<LearningRecord[]>([]);
   const [recordToEdit, setRecordToEdit] = useState<LearningRecord | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
   const { user } = useSession();
   const userId = user?.supabaseUserId ?? "";
 
@@ -68,6 +69,8 @@ const LearningHistory = () => {
 
   // 学習記録追加
   const handleAddRecord = async (newRecord: LearningRecord) => {
+    setIsSaving(true);
+
     try {
       const response = await fetch(`/api/user/learning-history`, {
         method: "POST",
@@ -86,6 +89,7 @@ const LearningHistory = () => {
       console.error(error);
       alert("学習記録の保存に失敗しました");
     }
+    setIsSaving(false);
   };
 
   // 学習記録削除
@@ -117,6 +121,8 @@ const LearningHistory = () => {
   };
 
   const handleSaveRecord = async (updatedRecord: LearningRecord) => {
+    setIsSaving(true);
+
     try {
       const response = await fetch(
         `/api/user/learning-history/${updatedRecord.id}`,
@@ -143,6 +149,7 @@ const LearningHistory = () => {
       console.error(error);
       alert("学習記録の保存に失敗しました");
     }
+    setIsSaving(false);
   };
 
   return (
@@ -162,6 +169,7 @@ const LearningHistory = () => {
           recordToEdit={recordToEdit}
           isEditing={recordToEdit !== null}
           setRecordToEdit={setRecordToEdit}
+          isSaving={isSaving}
         />
       </div>
 


### PR DESCRIPTION
## 概要

学習記録の保存処理 (`handleAddRecord` および `handleSaveRecord`) において、  
保存中状態 (`isSaving`) を適切に管理し、保存中に「保存中...」などの表示を行うように改善しました。

## 変更内容

- 保存処理開始時に `setIsSaving(true)` を実行
- 保存完了・エラー時に `setIsSaving(false)` を実行
- 保存中はボタンや画面上に「保存中...」のステータスを表示
- 連続操作防止のため、保存中はボタンを無効化 (`disabled`)

## 背景・目的

- 保存ボタンを押した際、保存処理が進行中であることをユーザーに明示するため
- 保存処理中の連続押下を防止し、サーバーへの不要なリクエストを防ぐため
- 全体のUX向上（処理中のフィードバックを出す設計）を目指すため

## 確認事項

- 保存開始時に「保存中...」が表示されること
- 保存完了後、「保存中...」が消えること
- 保存中はボタンが押せないこと
- 保存に失敗した場合も保存中表示が解除されること

## 関連Issue

Closes #75
