### PR TITLE
🔧 ヒートマップの時間基準をUTC→JSTに修正 (#77)

### DIFF
--- a/src/app/_utils/dateHelpers.ts
+++ b/src/app/_utils/dateHelpers.ts
@@ -1,0 +1,21 @@
+import { format, subDays } from "date-fns";
+import { toZonedTime } from "date-fns-tz";
+
+export const JST = "Asia/Tokyo";
+
+// JSTで日付を "yyyy-MM-dd" 形式に変換
+export const formatDateJST = (date: Date): string => {
+  return format(toZonedTime(date, JST), "yyyy-MM-dd");
+};
+
+// 過去n日分のJST日付（"yyyy-MM-dd"）を配列で取得
+export const getPastNDatesJST = (
+  n: number,
+  from: Date = new Date()
+): string[] => {
+  return Array.from({ length: n }, (_, i) => formatDateJST(subDays(from, i)));
+};
+
+// 2つの日付の差分（日数）を返す
+export const getDateDiffInDays = (date1: Date, date2: Date): number =>
+  Math.floor((date1.getTime() - date2.getTime()) / (1000 * 60 * 60 * 24));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,7 @@
     "paths": {
       "@/*": ["./src/*"],
       "@utils/*": ["src/app/_utils/*"], // _utils 以下をエイリアスで設定
-      "@hooks/*": ["src/app/_hooks/*"], // _utils 以下をエイリアスで設定
+      "@hooks/*": ["src/app/_hooks/*"], // _hooks 以下をエイリアスで設定
       "@components/*": ["src/app/_components/*"], // _components 以下をエイリアスで設定
       "@ui/*": ["src/app/_components/ui/*"] // ui 以下をエイリアスで設定
     }


### PR DESCRIPTION
### 🐛 概要
学習記録のヒートマップにおいて、日付の判定が **UTC基準** で行われていたため、日本時間（JST）での記録と表示にズレが生じていました。  
本PRでは、日付処理を **JSTに統一** し、視覚的な違和感が発生しないように修正しました。

---

### ✅ 修正内容

- `learning_date` を `Asia/Tokyo` タイムゾーンに変換する `formatDateJST()` 関数を使用
- 日付補完に `getPastNDatesJST()` を導入
- `/api/user/heatmap` のAPIレスポンスを JST基準で整形するように修正

---

### 🧪 動作確認

- [x] JST基準で学習時間が正しく集計されていることを確認
- [x] ヒートマップにおける表示が日本時間での記録内容と一致していることを確認
- [x] 記録がない日も `hours: 0` として正しく補完されていることを確認

---

### 📁 影響範囲

- `/api/user/heatmap` API
- フロントエンドで受け取るヒートマップデータの精度

---

### 💬 備考
今後、他の統計（週間チャート、ストリークなど）もJST基準に揃える必要があります。

---

### 🔗 関連Issue
Closes #77
