### PR TITLE
【リファクタリング】学習履歴画面を共通SWRデータで表示するように変更 #90

### DIFF
--- a/src/app/_hooks/useLearningRecords.ts
+++ b/src/app/_hooks/useLearningRecords.ts
@@ -3,27 +3,37 @@
 import useSWR, { mutate } from "swr";
 import { RawRecord } from "@/app/_types/formTypes";
 
+// -----------------------------
+// フェッチャー関数
+// -----------------------------
 const fetcher = async (url: string) => {
   const res = await fetch(url);
   if (!res.ok) throw new Error("データ取得失敗");
   return res.json();
 };
 
+// -----------------------------
+// SWRキャッシュキーの生成関数
+// -----------------------------
 const RECORDS_KEY = (userId: string) =>
   `/api/user/learning-record?supabaseUserId=${userId}&period=3months`;
 
+// -----------------------------
+// SWRによる学習記録取得フック
+// -----------------------------
 export function useLearningRecords(userId?: string) {
   const { data, error, isLoading } = useSWR<RawRecord[]>(
     userId ? RECORDS_KEY(userId) : null,
     fetcher
   );
 
+  // ✅ 手動でキャッシュ更新（再取得）
   const refreshLearningRecords = async (userId: string) => {
     if (!userId) return;
     const url = RECORDS_KEY(userId);
     try {
       const records = await fetcher(url);
-      mutate(url, records, false);
+      mutate(url, records, false); // 再検証なしでキャッシュ更新
     } catch (error) {
       console.error("学習記録の更新エラー:", error);
     }
@@ -35,4 +45,17 @@ export function useLearningRecords(userId?: string) {
     isError: error,
     refreshLearningRecords,
   };
+}
+
+// -----------------------------
+// ✅ ログイン時のプリロード関数（SWRキャッシュへ保存）
+// -----------------------------
+export async function preloadLearningRecords(userId: string) {
+  const url = RECORDS_KEY(userId);
+  try {
+    const records = await fetcher(url);
+    mutate(url, records, false); // SWR キャッシュに保存
+  } catch (error) {
+    console.error("学習記録の事前読み込みに失敗:", error);
+  }
 }


### PR DESCRIPTION
## 概要

学習履歴ページにおいて、これまで個別にAPIリクエストしていた学習記録データを、
ログイン時に取得済みのSWRキャッシュ（useLearningRecords）から利用するように変更しました。

---

## 主な変更点

- useLearningRecords フックを使って共通データを取得
- RawRecord → LearningRecord への変換処理を追加
- records の取得を SWR キャッシュに統一
- 追加・更新・削除処理後に mutate でキャッシュを更新
- 不要となった fetchLearningRecords 関連コードを削除

---

## 目的

- ログイン時に取得した学習記録を再利用し、APIの冗長な呼び出しを削減
- 複数ページ間での学習記録の一貫性を保つ

---

## 影響範囲

- `src/app/user/learning-history/page.tsx`

---

## 関連Issue

- #90 【リファクタリング】学習一覧データをログイン時に取得・保存し、SWRで共通利用するように変更

---

ご確認よろしくお願いします🙏
