### PR TITLE
機能追加: ヘッダーに問い合わせフォームリンクを追加

### DIFF
--- a/src/app/_components/ui/app-header.tsx
+++ b/src/app/_components/ui/app-header.tsx
@@ -12,6 +12,7 @@ import { Dialog, DialogTrigger, DialogContent } from "@radix-ui/react-dialog";
 import { Menu, LogOut, User, Settings } from "lucide-react";
 import { AppSidebar } from "./app-sidebar";
 import AppLogoLink from "../AppLogoLink";
+import { MessageSquare } from "lucide-react";
 
 export function AppHeader() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
@@ -138,6 +139,15 @@ export function AppHeader() {
             </DropdownMenu.Root>
           ) : (
             <>
+              <Button variant="ghost" asChild>
+                <Link
+                  href="https://forms.gle/VswqnpPY7FrJ5A146"
+                  className="flex items-center gap-2"
+                >
+                  <MessageSquare className="w-4 h-4" />
+                  フィードバック
+                </Link>
+              </Button>
               <Button variant="ghost" asChild>
                 <Link href="/login">ログイン</Link>
               </Button>


### PR DESCRIPTION
概要:
ヘッダーに問い合わせ用のGoogleフォームリンク（フィードバックリンク）を追加しました。

対応内容:
- ヘッダーに「フィードバック」ボタンを追加
- lucide-react の MessageSquare アイコンを付加
- Googleフォーム（https://forms.gle/VswqnpPY7FrJ5A146）に遷移するように設定
- asChild を使って Link コンポーネント内でボタンとして表示
- ボタンのスタイルは既存のUIコンポーネントに準拠

デザイン:
- テキストとアイコンの間に gap-2 を追加して視認性を向上
- アイコンサイズは w-4 h-4 に統一

関連Issue:
#93
