### PR TITLE
【修正】タイマー実行中のSidebarリンククリックでキャンセルしても遷移してしまう問題を修正 #85

### DIFF
--- a/src/app/_hooks/useTimerGuard.ts
+++ b/src/app/_hooks/useTimerGuard.ts
@@ -1,0 +1,11 @@
+import { useState } from "react";
+
+export function useTimerGuard() {
+  const [isLearning, setIsLearning] = useState(false);
+
+  return {
+    isLearning,
+    startTimer: () => setIsLearning(true),
+    stopTimer: () => setIsLearning(false),
+  };
+}


### PR DESCRIPTION
### 概要
タイマーが実行中の状態で Sidebar 内の「ダッシュボード」「学習記録」「学習履歴」リンクをクリックした際、キャンセルしてもページ遷移が発生してしまう不具合を修正しました。

### 変更内容
- Link による即時遷移を中止し、router.push を使った手動遷移に変更
- 該当リンクに `manualNav: true` を追加し、手動遷移と通常遷移を分離
- 確認ダイアログを表示し、キャンセル時は遷移を中止
- 対象：`/user/dashboard`, `/user/learning-record`, `/user/learning-history`,`/`,`/learning-support`

### 影響範囲
- メインメニューー
- サイドバーリンク（学習管理）

### 関連Issue
- #85
