### PR TITLE
🐛 不具合修正: タイマーが動作していなくても「実行中」警告が表示される問題を修正

### DIFF
--- a/src/app/_hooks/useTimerGuard.ts
+++ b/src/app/_hooks/useTimerGuard.ts
@@ -1,11 +1,48 @@
-import { useState } from "react";
+// src/app/_hooks/useTimerGuard.ts
+"use client";
+
+import { useState, useEffect } from "react";
 
 export function useTimerGuard() {
   const [isLearning, setIsLearning] = useState(false);
 
+  // ✅ タイマー実行中かどうかを判断するためのロジック
+  // isLearning: React側の状態管理
+  // localStorageにlearning_start_timeがあるかどうかも併用してチェックする
+  const isActuallyLearning =
+    isLearning && localStorage.getItem("learning_start_time") !== null;
+
+  // ✅ 初回マウント時にlocalStorageの不正な値をクリーンアップ
+  useEffect(() => {
+    const stored = localStorage.getItem("learning_start_time");
+    if (stored) {
+      const parsed = new Date(stored);
+      if (isNaN(parsed.getTime())) {
+        // 無効な日付なら削除
+        localStorage.removeItem("learning_start_time");
+        return;
+      }
+
+      const now = Date.now();
+      const elapsed = now - parsed.getTime();
+
+      // 任意の期限（12時間以上前など）を過ぎていたら削除
+      if (elapsed > 1000 * 60 * 60 * 12) {
+        localStorage.removeItem("learning_start_time");
+      }
+    }
+  }, []);
+
   return {
-    isLearning,
-    startTimer: () => setIsLearning(true),
-    stopTimer: () => setIsLearning(false),
+    isLearning: isActuallyLearning, // ✅ タイマー実行中判定
+    startTimer: () => {
+      const now = new Date().toISOString();
+      localStorage.setItem("learning_start_time", now);
+      setIsLearning(true);
+    },
+    stopTimer: () => {
+      localStorage.removeItem("learning_start_time");
+      setIsLearning(false);
+    },
   };
 }

--- a/src/app/user/learning-record/page.tsx
+++ b/src/app/user/learning-record/page.tsx
@@ -33,6 +33,17 @@ export default function TimeInputPage() {
   // 最新学習記録
   const [recentLearning, setRecentLearning] = useState<LearningRecord[]>([]);
 
+  // ✅ 初回マウント時に learning_start_time の整合性を確認し、不正なら削除
+  useEffect(() => {
+    const stored = localStorage.getItem("learning_start_time");
+    if (stored) {
+      const parsed = new Date(stored);
+      if (isNaN(parsed.getTime())) {
+        localStorage.removeItem("learning_start_time");
+      }
+    }
+  }, []);
+
   // ✅ タイマー実行中のナビゲーションガード（リロードや画面移動を防止）
   useEffect(() => {
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
@@ -190,6 +201,7 @@ export default function TimeInputPage() {
       setIsLearning(false);
       setStartTime(null);
       fetchLearningRecords();
+      localStorage.removeItem("learning_start_time");
     } catch (err) {
       console.error("保存エラー:", err);
       toast({
@@ -220,6 +232,7 @@ export default function TimeInputPage() {
     setNewCategory("");
     setContent("");
     toast({ title: "リセットしました" });
+    localStorage.removeItem("learning_start_time");
   }, []);
 
   // ✅ 学習履歴ページへ遷移


### PR DESCRIPTION
## 概要

タイマーを開始していない状態でも、サイドバーの「ダッシュボード」や「学習履歴」をクリックすると  
「タイマーが実行中です。このまま移動するとタイマーが停止しますが、よろしいですか？」  
という警告ダイアログが表示されてしまう不具合が発生していました。

## 修正内容

- 初回マウント時に `learning_start_time` の値が不正（無効な日付など）な場合は削除
- タイマー停止時とリセット時に `localStorage.removeItem("learning_start_time")` を追加
- `isLearning` 状態と localStorage の内容が不一致にならないよう整備

## 関連ファイル

- `src/app/user/learning-record/page.tsx`

## 関連Issue

- Close #99

## 備考

- タイマーが「実際に動作しているときのみ」警告が表示されるようになります。
