### PR TITLE
🚀 機能追加：アカウント作成時に「登録中...」表示を追加

### DIFF
--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -7,6 +7,7 @@ import { Button } from "@ui/button";
 import { Input } from "@ui/input";
 import { SignUpFormData } from "@/app/_types/formTypes";
 import AppLogoLink from "../_components/AppLogoLink";
+import { useState } from "react";
 
 export default function SignUpPage() {
   const {
@@ -16,8 +17,10 @@ export default function SignUpPage() {
     setError, // setError を使用する
     watch,
   } = useForm<SignUpFormData>();
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const onSubmit = async (data: SignUpFormData) => {
+    setIsSubmitting(true); // ✅ 開始時に状態を更新
     const { email, password, nickname } = data;
 
     // Supabase 認証のサインアップ
@@ -65,6 +68,7 @@ export default function SignUpPage() {
         }
       }
     }
+    setIsSubmitting(false); // ✅ 完了時に状態を更新
   };
 
   // パスワード確認のバリデーション
@@ -182,9 +186,10 @@ export default function SignUpPage() {
 
         <Button
           type="submit"
-          className="w-full h-10 bg-pink-500 hover:bg-pink-600"
+          disabled={isSubmitting}
+          className="w-full h-10 bg-pink-500 hover:bg-pink-600 disabled:opacity-50"
         >
-          アカウントを作成
+          {isSubmitting ? "登録中..." : "アカウントを作成"}
         </Button>
       </form>
     </div>


### PR DESCRIPTION
## 🔧 概要
アカウント作成処理中に、ユーザーが処理中であることを認識できるようにするため、「登録中...」という表示を追加しました。

## ✅ 変更内容

- useState を用いて isSubmitting を管理
- onSubmit 処理前に isSubmitting = true、完了後に false
- 登録ボタンのテキストを状態に応じて切り替え
  - 登録中... → 登録処理中
  - アカウントを作成 → 通常状態
- ローディング中は disabled にして二重送信防止

## 📄 該当ファイル
src/app/signup/page.tsx

## 📝 備考
ローディングスピナーなどを今後追加することで、さらにUXを向上させる余地があります。