### PR TITLE
サインアップ時のSupabase Auth + Userテーブル登録処理をトランザクション風に整備する #103

### DIFF
--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -2,38 +2,48 @@ import { prisma } from "@/app/_utils/prisma";
 
 export async function POST(request: Request) {
   try {
-    // リクエストボディからnicknameとsupabaseUserIdを抽出
+    // リクエストボディから必要な情報を取得
     const { nickname, supabaseUserId } = await request.json();
 
-    // ユーザーがすでに存在するかチェック
-    const existingUser = await prisma.user.findUnique({
-      where: {
-        supabaseUserId: supabaseUserId, // supabaseUserId で検索
-      },
+    // ✅ トランザクションで一連の処理をラップ（すべて成功するか、すべてロールバック）
+    const result = await prisma.$transaction(async (tx) => {
+      // 1. すでに同じ supabaseUserId を持つユーザーが存在するか確認
+      const existingUser = await tx.user.findUnique({
+        where: { supabaseUserId },
+      });
+
+      // 2. 存在すれば例外を投げてトランザクションを中断（ロールバックされる）
+      if (existingUser) {
+        throw new Error("ユーザーはすでに存在します。");
+      }
+
+      // 3. 新規ユーザー作成（ここに関連テーブル追加などの処理を追加可能）
+      const newUser = await tx.user.create({
+        data: {
+          supabaseUserId,
+          nickname,
+          roleId: 1, // デフォルトのロール（例: 一般ユーザー）
+        },
+      });
+
+      // 4. 作成したユーザー情報を返す（トランザクション成功時のみ）
+      return newUser;
     });
 
-    // すでにユーザーが存在する場合はエラーメッセージを返す
-    if (existingUser) {
-      return new Response(
-        JSON.stringify({ message: "ユーザーはすでに存在します。" }),
-        { status: 400 }
-      );
-    }
-
-    // 新しいユーザーを作成（デフォルトのroleIdは1）
-    const newUser = await prisma.user.create({
-      data: {
-        supabaseUserId,
-        nickname,
-        roleId: 1, // デフォルトでroleId 1
-      },
-    });
-
-    // 作成したユーザー情報を返す
-    return new Response(JSON.stringify(newUser), { status: 200 });
-  } catch (error) {
-    // エラーログを出力し、エラーレスポンスを返す
+    // ✅ トランザクションが正常に完了した場合、200 OK を返す
+    return new Response(JSON.stringify(result), { status: 200 });
+  } catch (error: unknown) {
+    // ❌ トランザクション失敗または他のエラー発生時の処理
     console.error("ユーザー情報の保存に失敗しました", error);
-    return new Response("ユーザー情報の保存に失敗しました", { status: 500 });
+
+    // エラー内容を整形してレスポンスに含める
+    const errorMessage =
+      error instanceof Error && error.message === "ユーザーはすでに存在します。"
+        ? error.message
+        : "ユーザー情報の保存に失敗しました";
+
+    return new Response(JSON.stringify({ message: errorMessage }), {
+      status: 500,
+    });
   }
 }


### PR DESCRIPTION
## 内容

- サインアップ時、Supabase Authでのユーザー作成成功後に、UserテーブルにnicknameとsupabaseUserIdを保存する処理を実装
- Prismaの$transactionを使用して、同一supabaseUserIdがすでに存在する場合はエラーを返し、重複登録を防止
- 例外発生時は適切なエラーメッセージを返すように処理を分岐

## 目的

- Supabase認証とUserテーブル登録を一連の安全な処理として扱うことで、データの一貫性を確保するため
- トランザクション的に動作することで、将来的に関連テーブル（プロフィールなど）を追加しても破綻しない構造にするため

## 関連Issue
Closes #103

