### PR TITLE
🔀 機能追加：ログアウト時にSWRキャッシュを明示的にクリアする

### DIFF
--- a/src/app/_hooks/useLogout.ts
+++ b/src/app/_hooks/useLogout.ts
@@ -1,19 +1,25 @@
-import { supabase } from "@utils/supabase";
-import { mutate } from "swr"; // mutate をインポート
+import { mutate } from "swr";
 import { useRouter } from "next/navigation";
+import { supabase } from "@utils/supabase";
 
 export const useLogout = () => {
   const router = useRouter();
 
   const handleLogout = async () => {
-    const { error } = await supabase.auth.signOut(); // サインアウト処理
+    const { error } = await supabase.auth.signOut();
+
     if (error) {
-      console.error("ログアウト失敗:", error.message); // エラーメッセージの表示
+      console.error("ログアウト失敗:", error.message);
     } else {
-      console.log("ログアウトしました"); // ログアウト完了
-      // mutateを使用してキャッシュを無効化して、ユーザー情報をリセット
+      console.log("ログアウトしました");
+
+      // ✅ 明示的にキャッシュキーを個別にクリア
       mutate("user", null);
-      // ログアウト後にホームにリダイレクト
+      mutate("/api/dashboard", null);
+      mutate("/api/user/profile", null);
+      mutate("/api/learning-record", null);
+      // 必要に応じて他のキーも追加
+
       router.push("/login");
     }
   };


### PR DESCRIPTION
Closes #108

## ✅ 概要
ログアウト後もSWRのキャッシュが保持されていたため、ログアウト直後にログインユーザーの情報が一時的に表示される問題がありました。
この対応として、mutate(key, null) を用いて、主要なキャッシュキーをログアウト時に明示的に無効化するようにしました。

## 🛠 変更点
-useLogout.ts にて以下のキャッシュキーを mutate() でリセット：
  - "user"
  - "/api/dashboard"
  - "/api/user/profile"
  - "/api/learning-record"（※仮キー、プロジェクトに応じて調整）

## 📌 補足
getCache() 等のグローバルキャッシュ操作APIは swr@2.3.3 では使用できないため、現時点ではこのように明示的に個別クリアする方法が最適です。
将来的に getCache() が導入された場合はリファクタリング候補です。