### PR TITLE
🔧 学習時間の表示を小数点第1位に丸める処理を追加

### DIFF
--- a/src/app/user/learning-history/_components/LearningRecordTable.tsx
+++ b/src/app/user/learning-history/_components/LearningRecordTable.tsx
@@ -80,7 +80,7 @@ const LearningRecordTable: React.FC<LearningRecordTableProps> = ({
               <TableCell>
                 {extractTime(record.startTime)} - {extractTime(record.endTime)}
                 <div className="text-xs text-muted-foreground">
-                  {record.duration}時間
+                  {record.duration.toFixed(1)}時間
                 </div>
               </TableCell>
               <TableCell className="hidden md:table-cell max-w-xs truncate">


### PR DESCRIPTION
## 概要
学習記録の表示において、duration（学習時間）が小数点以下多数表示されていた（例：4.920662222222222）。
本プルリクでは、duration を .toFixed(1) により小数点第1位で表示するように変更し、UIの可読性を改善しています。

## 変更内容
- LearningRecordTable.tsx の時間表示部分を以下のように修正：
```
{record.duration.toFixed(1)}時間
```

## 効果
表示がスッキリし、ユーザーにとって視認性が向上
- 例：4.920662222222222 → 4.9

備考
- duration が number 型であることを前提としています。

