### PR TITLE
🔒 ログイン状態の保持機能を追加（localStorage対応）

### DIFF
--- a/src/app/_utils/supabase.ts
+++ b/src/app/_utils/supabase.ts
@@ -1,6 +1,20 @@
 import { createClient } from "@supabase/supabase-js";
 
+const getStorage = () => {
+  if (typeof window === "undefined") return undefined;
+  const persist = localStorage.getItem("persistLogin");
+  return persist === "true" ? localStorage : sessionStorage;
+};
+
 export const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+  {
+    auth: {
+      storage: typeof window !== "undefined" ? getStorage() : undefined,
+      autoRefreshToken: true,
+      persistSession: true,
+      detectSessionInUrl: true,
+    },
+  }
 );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,68 +1,89 @@
 "use client";
 
 import { useState } from "react";
-import { supabase } from "@utils/supabase"; // Supabaseクライアント
-import { useRouter } from "next/navigation"; // Next.jsのrouter
-import { useForm } from "react-hook-form"; // フォーム管理
-import { Label } from "@ui/label"; // ラベルUIコンポーネント
-import { Button } from "@ui/button"; // ボタンUIコンポーネント
-import { Input } from "@ui/input"; // 入力フィールドUIコンポーネント
-import Link from "next/link"; // ページ遷移用Link
-import { LoginFormData } from "@/app/_types/formTypes"; // フォームデータ型
-import AppLogoLink from "../_components/AppLogoLink"; // ロゴリンクコンポーネント
-import { useLearningRecords } from "@/app/_hooks/useLearningRecords"; // ✅ 学習記録フェッチ用カスタムフック
+import { supabase } from "@utils/supabase";
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { Label } from "@ui/label";
+import { Button } from "@ui/button";
+import { Input } from "@ui/input";
+import Link from "next/link";
+import { LoginFormData } from "@/app/_types/formTypes";
+import AppLogoLink from "../_components/AppLogoLink";
+import { useLearningRecords } from "@/app/_hooks/useLearningRecords";
 
 export default function LoginPage() {
-  const [error, setError] = useState<string | null>(null); // 認証エラーメッセージ
-  const [emailSent, setEmailSent] = useState<boolean>(false); // メール再送信フラグ
-  const router = useRouter(); // ページ遷移用
-  const { refreshLearningRecords } = useLearningRecords(); // ✅ 学習記録のキャッシュ更新関数
+  // -------------------------------
+  // 状態管理
+  // -------------------------------
+  const [error, setError] = useState<string | null>(null); // 認証エラー表示
+  const [emailSent, setEmailSent] = useState<boolean>(false); // 確認メール送信済み状態
+  const [rememberMe, setRememberMe] = useState<boolean>(false); // ✅ ログイン保持の選択状態
+  const router = useRouter();
+  const { refreshLearningRecords } = useLearningRecords();
 
+  // react-hook-form によるフォーム状態管理
   const {
     register,
     handleSubmit,
     formState: { errors },
     getValues,
-  } = useForm<LoginFormData>(); // react-hook-formによるフォーム管理
+  } = useForm<LoginFormData>();
 
+  // -------------------------------
   // ログイン処理
+  // -------------------------------
   const handleLogin = async (email: string, password: string) => {
-    console.log("ログイン処理開始", { email });
+    console.log("ログイン処理開始", { email, rememberMe });
 
+    // ✅ 永続ログイン状態の保存（storage の切り替え）
+    if (typeof window !== "undefined") {
+      if (rememberMe) {
+        localStorage.setItem("persistLogin", "true");
+        sessionStorage.removeItem("persistLogin");
+      } else {
+        sessionStorage.setItem("persistLogin", "false");
+        localStorage.removeItem("persistLogin");
+      }
+    }
+
+    // Supabase でログイン試行
     const { data: userData, error: authError } =
       await supabase.auth.signInWithPassword({
         email,
         password,
       });
 
+    // 認証失敗時の処理
     if (authError) {
-      console.log("認証エラー:", authError.message);
-      setError(authError.message);
-
+      console.error("認証エラー:", authError.message);
       if (authError.message === "Email not confirmed") {
         setError("メールアドレスが未確認です。確認メールを開封してください。");
+      } else {
+        setError(authError.message);
       }
       return null;
     }
 
+    // 認証成功・確認済みチェック
     if (userData?.user?.confirmed_at) {
-      console.log("ログイン成功:", userData.user);
       setError(null);
       return userData.user;
     } else {
-      console.log("未確認のメールアドレス");
       setError("メールアドレスが未確認です。確認メールを開封してください。");
       return null;
     }
   };
 
-  // 確認メール再送信
+  // -------------------------------
+  // 確認メール再送信処理
+  // -------------------------------
   const resendVerificationEmail = async () => {
     const email = getValues("email");
 
     const { error } = await supabase.auth.signUp({
       email,
-      password: "temporarypassword",
+      password: "temporarypassword", // 仮のパスワードで再送要求
     });
 
     if (error) {
@@ -73,28 +94,32 @@ export default function LoginPage() {
     }
   };
 
-  // フォーム送信時の処理
+  // -------------------------------
+  // フォーム送信処理（ログイン本体）
+  // -------------------------------
   const onSubmit = async (data: LoginFormData) => {
     setError(null);
     const user = await handleLogin(data.email, data.password);
 
     if (user) {
-      // ✅ ログイン後に学習記録（直近3ヶ月）を取得してキャッシュ
+      // ✅ ログイン成功時：学習記録プリロード
       await refreshLearningRecords(user.id);
       console.log("✅ 学習記録の取得とキャッシュ成功");
 
-      // ✅ ダッシュボードに遷移
+      // ✅ ダッシュボードへリダイレクト
       router.push("/user/dashboard");
     }
   };
 
   return (
-    <div className="min-h-screen flex justify-center">
+    <div className="min-h-screen flex justify-center items-center px-4">
       <form
         onSubmit={handleSubmit(onSubmit)}
-        className="w-full max-w-md space-y-6"
+        className="w-full max-w-md space-y-6 bg-white p-8 rounded shadow"
       >
-        {/* ロゴとタイトル */}
+        {/* -------------------- */}
+        {/* ロゴ・タイトルセクション */}
+        {/* -------------------- */}
         <div className="text-center">
           <AppLogoLink
             href="/"
@@ -104,18 +129,20 @@ export default function LoginPage() {
             iconColor="text-pink-500"
             bgColor="bg-pink-50"
           />
-          <h1 className="text-2xl font-semibold">ログイン</h1>
+          <h1 className="text-2xl font-semibold mt-2">ログイン</h1>
           <p className="text-sm text-gray-600 mt-2">
             アカウントをお持ちでない方は、
-            <Link href="/signup" className="text-pink-500">
+            <Link href="/signup" className="text-pink-500 hover:underline">
               こちらから登録
             </Link>
           </p>
         </div>
 
-        {/* フォーム入力エリア */}
+        {/* -------------------- */}
+        {/* 入力フィールド */}
+        {/* -------------------- */}
         <div className="space-y-4">
-          {/* メールアドレス入力 */}
+          {/* メールアドレス */}
           <div className="space-y-1">
             <Label htmlFor="email">メールアドレス</Label>
             <Input
@@ -125,7 +152,7 @@ export default function LoginPage() {
               {...register("email", {
                 required: "メールアドレスは必須です",
                 pattern: {
-                  value: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+                  value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
                   message: "無効なメールアドレスです",
                 },
               })}
@@ -136,7 +163,7 @@ export default function LoginPage() {
             )}
           </div>
 
-          {/* パスワード入力 */}
+          {/* パスワード */}
           <div className="space-y-1">
             <Label htmlFor="password">パスワード</Label>
             <Input
@@ -157,10 +184,24 @@ export default function LoginPage() {
             )}
           </div>
 
-          {/* エラーメッセージ表示 */}
-          {error && <p className="text-red-500 text-sm">{error}</p>}
+          {/* ✅ ログイン状態保持チェックボックス */}
+          <div className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              id="rememberMe"
+              checked={rememberMe}
+              onChange={() => setRememberMe((prev) => !prev)}
+              className="accent-pink-500"
+            />
+            <label htmlFor="rememberMe" className="text-sm text-gray-700">
+              ログイン状態を保持する（localStorage）
+            </label>
+          </div>
 
-          {/* 確認メール再送信案内 */}
+          {/* エラー表示 */}
+          {error && <p className="text-sm text-red-500">{error}</p>}
+
+          {/* メール未確認時の案内 */}
           {error ===
             "メールアドレスが未確認です。確認メールを開封してください。" && (
             <div className="mt-4">
@@ -180,7 +221,9 @@ export default function LoginPage() {
           )}
         </div>
 
+        {/* -------------------- */}
         {/* ログインボタン */}
+        {/* -------------------- */}
         <Button
           type="submit"
           className="w-full bg-pink-500 text-white hover:bg-pink-600"


### PR DESCRIPTION

Closes #121

## ✨ 概要
ユーザーが「ログイン状態を保持する」を選択した場合、localStorage にフラグを保存し、次回ブラウザ起動時にもログイン状態を維持できるようにするための対応を行いました。

## ✅ 変更点

- ログインフォームに ログイン状態を保持する チェックボックスを追加
- ユーザーの選択に応じて localStorage または sessionStorage に persistLogin フラグを保存
- Supabase ログイン時の設定を拡張可能な形で調整（将来的なセッション保持方式切り替えのため）
- UI 説明文も合わせて調整（チェックボックスラベル）

## 💾 保存ロジック仕様

| 選択肢                             | 保存先         | セッションの挙動                     |
|----------------------------------|----------------|------------------------------------|
| ✅ ログイン状態を保持する（チェックあり） | `localStorage` | ブラウザを閉じてもログイン状態が維持される |
| ⬜ チェックなし                     | `sessionStorage` | タブやブラウザを閉じるとログアウトされる     |

## 📷 スクリーンショット
<img width="642" alt="スクリーンショット 2025-05-14 15 47 22" src="https://github.com/user-attachments/assets/5496df50-0b03-4396-bdc3-5be050555451" />

## 📝 補足
- 今後このフラグを元に、Supabase クライアントの persistSession 設定と連動させることを検討中です。
- 現時点では、ログイン時に明示的な保持設定としてローカル/セッションストレージに値を保存しています。


