### PR TITLE
♻️ #115 ログイン時の refreshLearningRecords 呼び出しを削除し、preloadLearningRecords に一本化

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -102,11 +102,7 @@ export default function LoginPage() {
     const user = await handleLogin(data.email, data.password);
 
     if (user) {
-      // ✅ ログイン成功時：学習記録プリロード
-      await refreshLearningRecords(user.id);
-      console.log("✅ 学習記録の取得とキャッシュ成功");
-
-      // ✅ ダッシュボードへリダイレクト
+      // ✅ 学習記録はセッション取得時にプリロード済み
       router.push("/user/dashboard");
     }
   };


### PR DESCRIPTION
## 概要

ログイン時に `refreshLearningRecords()` を呼び出していた処理を削除し、セッション取得時に `preloadLearningRecords()` でキャッシュされるように統一しました。

## 背景

- `useSession()` 内の `fetchUserData()` にて `preloadLearningRecords()` をすでに呼び出している。
- ログイン直後に `refreshLearningRecords()` を再度呼び出すと、**不要なネットワークリクエストが発生**する。
- `refreshLearningRecords()` は本来、**ユーザー操作による再取得用途**のため、本来の意図と異なっていた。

## 変更内容

- `LoginPage.tsx` 内の `onSubmit` から `refreshLearningRecords(user.id)` を削除
- ログイン後のキャッシュ登録は `useSession` 経由で自動的に行われる形に整理

## メリット

- ロジックの重複を排除し、コードの整合性と意図が明確になる
- 学習記録のフェッチが一度だけ行われ、表示パフォーマンスにも貢献

## 今後の展望

- `fallbackData` や `SWRConfig` を使った初期データ注入の検討（表示高速化）

