### PR TITLE
`manualNav: true` を追加して、ログイン・サインアップリンクの遷移を修正

### DIFF
--- a/src/app/_components/ui/app-sidebar.tsx
+++ b/src/app/_components/ui/app-sidebar.tsx
@@ -187,17 +187,25 @@ export function AppSidebar() {
         label: "進捗管理（管理者用）",
       },
     ],
+
+    // ログインしていないユーザー向けのメニュー
     loggedOut: [
-      { href: "/", icon: Home, label: "ホーム" },
-      { href: "/learning-support", icon: BookOpen, label: "学習サポート概要" },
+      { href: "/", icon: Home, label: "ホーム", manualNav: true },
+      {
+        href: "/learning-support",
+        icon: BookOpen,
+        label: "学習サポート概要",
+        // manualNav: true,
+      },
       {
         href: "/blog/success-stories",
         icon: Award,
         label: "成功事例",
         isUnderDevelopment: true,
+        // manualNav: true,
       },
-      { href: "/login", icon: LogOut, label: "ログイン" },
-      { href: "/signup", icon: User, label: "アカウント作成" },
+      { href: "/login", icon: LogOut, label: "ログイン", manualNav: true },
+      { href: "/signup", icon: User, label: "アカウント作成", manualNav: true },
     ],
   };
 


### PR DESCRIPTION
### 概要:
ログイン・サインアップリンクに `manualNav: true` を追加し、リンク遷移が正常に動作するように修正しました。これにより、リンクがクリックされた際に遷移処理が正しく行われるようになりました。

### 修正内容:
- ログインおよびサインアップリンクに `manualNav: true` を追加。
- `manualNav: true` を設定することで、リンク遷移が正常に機能するようになりました。

### 修正したファイル:
- `src/app/_components/ui/app-sidebar.tsx`

### 期待される動作:
- `ログイン` と `アカウント作成` のリンクをクリックすると、正常に遷移すること。
- 他のメニューリンクも従来通り正常に遷移すること。

### 変更点:
- ログインとサインアップリンクに `manualNav: true` を追加し、遷移処理を手動で行うようにしました。

### 関連するIssue:
- クローズ対象: #126
