### PR TITLE
#136: route.ts：学習記録IDの存在チェックとコメント整理

### DIFF
--- a/src/app/_utils/auth.ts
+++ b/src/app/_utils/auth.ts
@@ -1,0 +1,12 @@
+import { supabase } from "@utils/supabase";
+import { NextRequest } from "next/server";
+
+export async function getCurrentUser(request: NextRequest) {
+  const token = request.headers.get("authorization")?.split(" ")[1];
+  if (!token) {
+    return { error: "トークンがありません", data: null };
+  }
+
+  const { data, error } = await supabase.auth.getUser(token);
+  return { data, error };
+}

--- a/src/app/_utils/idValidators.ts
+++ b/src/app/_utils/idValidators.ts
@@ -1,0 +1,10 @@
+export function parseLearningRecordId(id: string): {
+  value: number | null;
+  error?: string;
+} {
+  const recordId = Number(id);
+  if (isNaN(recordId) || recordId <= 0) {
+    return { value: null, error: "無効な学習記録IDです" };
+  }
+  return { value: recordId };
+}


### PR DESCRIPTION
### 概要

Pull Request #135 のコードレビューコメントに基づき、以下の修正を行いました。

### ✅ 修正内容

- `params.learningRecordId` の存在チェックを削除  
  - `[learningRecordId]` という Next.js のルーティング定義により、通常は `learningRecordId` が存在しない状況は発生しないため。
- 不要または曖昧なコメントを整理・明確化

### 📁 対象ファイル

- `src/app/api/user/learning-history/[learningRecordId]/route.ts`

### 🔗 関連Issue

Closes #136  
Parent: #135

---


