### PR TITLE
ログイン不要ページにsignup追加

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -26,6 +26,7 @@ export async function middleware(req: NextRequest) {
     const isPublicPage =
       req.nextUrl.pathname === "/" || // ホーム
       req.nextUrl.pathname.startsWith("/login") || // ログイン
+      req.nextUrl.pathname.startsWith("/signup") || // 新規登録
       req.nextUrl.pathname.startsWith("/register"); // 登録など
 
     // 未ログインかつ公開ページでない場合は /login にリダイレクト


### PR DESCRIPTION
### ✅ 変更内容
middleware.ts の isPublicPage 判定に /signup を追加しました。


```
const isPublicPage =
  req.nextUrl.pathname === "/" ||
  req.nextUrl.pathname.startsWith("/login") ||
  req.nextUrl.pathname.startsWith("/register") || // ← 追加
  req.nextUrl.pathname.startsWith("/signup");     // ✅ 追加
```
### 🔒 意図
新規登録ページ（/signup）はログイン不要でアクセスできる必要があるため、ミドルウェアの保護対象外とする修正です。

### 🧪 テスト内容
未ログイン状態で /signup にアクセス → ✅ 表示されることを確認済み。

その他の保護対象ページでは、セッションがないと /login にリダイレクトされる挙動も問題なし。

### 🏷 ブランチ名
feature/issue145-allow-signup-without-auth