### PR TITLE
カテゴリー選択UIを親子構造に対応

### DIFF
--- a/prisma/migrations/20250609214218_add_parent_to_category/migration.sql
+++ b/prisma/migrations/20250609214218_add_parent_to_category/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Category" ADD COLUMN     "parentId" INTEGER;
+
+-- AddForeignKey
+ALTER TABLE "Category" ADD CONSTRAINT "Category_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "Category"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,6 +51,10 @@ model Follower {
 model Category {
   id                       Int                      @id @default(autoincrement())
   category_name            String
+  parentId                 Int?
+  parent                  Category?                @relation("CategoryHierarchy", fields: [parentId], references: [id])
+  children                Category[]               @relation("CategoryHierarchy") // 子カテゴリたち
+
   learningRecords          LearningRecord[]
   learningRecordCategories LearningRecordCategory[]
 }

--- a/src/app/_components/CategoryTree.tsx
+++ b/src/app/_components/CategoryTree.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import React from "react";
+import type { Category } from "../_types/formTypes";
+
+interface Props {
+  categories: Category[];
+}
+
+export function CategoryTree({ categories }: Props) {
+  console.log("Rendering CategoryTree with categories:", categories);
+  return (
+    <ul className="list-disc pl-4">
+      {categories.map((cat) => (
+        <li key={cat.id} className="mb-1">
+          <span>{cat.category_name}</span>
+
+          {(cat.children?.length ?? 0) > 0 && (
+            <div className="ml-4 mt-1">
+              <CategoryTree categories={cat.children ?? []} />
+            </div>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/app/_types/formTypes.ts
+++ b/src/app/_types/formTypes.ts
@@ -54,6 +54,8 @@ export type UserProfile = {
 export interface Category {
   id: number; // カテゴリーID（カテゴリーの一意な識別子）
   category_name: string; // カテゴリー名（例: "プログラミング", "数学" など）
+  parent_id?: number | null; // 親カテゴリID（ルートなら null）
+  children?: Category[]; // 子カテゴリ（再帰的構造）
 }
 
 // 生データの型を定義（APIなどから取得する元データに対応）

--- a/src/app/api/category/hierarchical/route.ts
+++ b/src/app/api/category/hierarchical/route.ts
@@ -1,0 +1,15 @@
+// /app/api/category/hierarchical/route.ts
+import { prisma } from "@utils/prisma";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const categories = await prisma.category.findMany({
+    where: { parentId: null },
+    include: {
+      children: true,
+    },
+  });
+
+  console.log("Hierarchical categories fetched:", categories);
+  return NextResponse.json(categories);
+}

--- a/src/app/user/learning-history/_components/LearningRecordDialog.tsx
+++ b/src/app/user/learning-history/_components/LearningRecordDialog.tsx
@@ -51,7 +51,7 @@ const LearningRecordDialog = ({
   // サーバーからカテゴリー情報を取得
   const fetchCategories = async () => {
     try {
-      const response = await fetch("/api/category");
+      const response = await fetch("/api/category/hierarchical");
       if (!response.ok) {
         throw new Error("カテゴリーの取得に失敗しました");
       }
@@ -188,10 +188,15 @@ const LearningRecordDialog = ({
             >
               <option value="">カテゴリーを選択</option>
               {categories.length > 0 ? (
-                categories.map((category) => (
-                  <option key={category.id} value={category.id}>
-                    {category.category_name}
-                  </option>
+                categories.map((parent) => (
+                  <React.Fragment key={parent.id}>
+                    <option value={parent.id}>{parent.category_name}</option>
+                    {parent.children?.map((child) => (
+                      <option key={child.id} value={child.id}>
+                        ┗ {child.category_name}
+                      </option>
+                    ))}
+                  </React.Fragment>
                 ))
               ) : (
                 <option disabled>カテゴリが読み込まれませんでした</option>

--- a/src/app/user/learning-record/_components/LearningInfoCard.tsx
+++ b/src/app/user/learning-record/_components/LearningInfoCard.tsx
@@ -17,10 +17,7 @@ import {
   SelectItem,
 } from "@ui/select";
 
-interface Category {
-  id: number;
-  category_name: string;
-}
+import { Category } from "@/app/_types/formTypes";
 
 interface Props {
   title: string;
@@ -46,7 +43,7 @@ export default function LearningInfoCard({
   useEffect(() => {
     const fetchCategories = async () => {
       try {
-        const res = await fetch("/api/category");
+        const res = await fetch("/api/category/hierarchical");
         const data = await res.json();
         setCategories(data);
       } catch (error) {
@@ -90,11 +87,18 @@ export default function LearningInfoCard({
             <SelectTrigger>
               <SelectValue placeholder="カテゴリを選択" />
             </SelectTrigger>
-            <SelectContent>
-              {categories.map((cat) => (
-                <SelectItem key={cat.id} value={cat.id.toString()}>
-                  {cat.category_name}
-                </SelectItem>
+            <SelectContent className="max-h-64 overflow-y-auto">
+              {categories.map((parent) => (
+                <React.Fragment key={parent.id}>
+                  <div className="px-3 py-1 text-xs font-bold text-muted-foreground">
+                    {parent.category_name}
+                  </div>
+                  {parent.children?.map((child) => (
+                    <SelectItem key={child.id} value={child.id.toString()}>
+                      ┗ {child.category_name}
+                    </SelectItem>
+                  ))}
+                </React.Fragment>
               ))}
               <SelectItem value="その他">その他</SelectItem>
             </SelectContent>


### PR DESCRIPTION
## 📝 PR概要

### ✅ 変更内容

- カテゴリーテーブルに親子関係（階層構造）を追加
- Prismaマイグレーション
  - `parentId` カラムを追加
  - 自己参照の外部キー制約を設定
- Prismaスキーマ修正
  - `parent` と `children` のリレーションを定義
- API追加
  - `/api/category/hierarchical` エンドポイントを作成（親子構造で取得）
- フロントエンド修正
  - カテゴリー選択UIを親子構造対応に変更
  - 再帰的に表示する `CategoryTree` コンポーネントを新規作成
  - `LearningRecordDialog` と `LearningInfoCard` に階層表示のドロップダウンを適用

---

## 🎯 このPRの目的

- カテゴリーの親子関係をサポートし、より柔軟な分類ができるようにする
- ユーザーがカテゴリーを視覚的に選択しやすくする

---

## 🗂 変更ファイル一覧

- `prisma/schema.prisma`
- `prisma/migrations/*`
- `src/app/api/category/hierarchical/route.ts`
- `src/app/_types/formTypes.ts`
- `src/app/_components/CategoryTree.tsx`
- `src/app/user/learning-history/_components/LearningRecordDialog.tsx`
- `src/app/user/learning-record/_components/LearningInfoCard.tsx`

---

## 🚩 補足

- 既存の `/api/category` は変更なし
- 新規 `/api/category/hierarchical` は親カテゴリとその子カテゴリをまとめて取得可能
- 現時点では2階層まで対応（必要なら更に拡張可能）

---

## 🔥 今後のタスク（別PR予定）

- カテゴリー一覧画面にツリー構造を導入
- サイドバーやランキング画面にも階層表示を適用
